### PR TITLE
Typo fix

### DIFF
--- a/common.h
+++ b/common.h
@@ -40,7 +40,7 @@ struct pids_t {
 
 struct constchar_t {
 	const char *value;
-	 LIST_ENTRY(pids_t) pointers;
+	 LIST_ENTRY(constchar_t) pointers;
 };
 
 enum mode_t {


### PR DESCRIPTION
Looks like a copy/paste error from the pids_t definition above. Discovered due to a trial compilation on Debian Wheezy (looks like Wheezy is missing linux/seccomp.h anyways).