### PR TITLE
Move definition of _FORTIFY_SOURCE to nsjail.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 CC = gcc
 CFLAGS += -O2 -g -ggdb -c -std=c11 \
 	-D_GNU_SOURCE \
-	-fstack-protector-all -Wformat -Wformat=2 -Wformat-security -fPIE -D_FORTIFY_SOURCE=2 -Wa,--noexecstack \
+	-fstack-protector-all -Wformat -Wformat=2 -Wformat-security -fPIE -Wa,--noexecstack \
 	-Wall -Wextra -Werror
 
 LD = gcc

--- a/nsjail.h
+++ b/nsjail.h
@@ -4,6 +4,7 @@
    -----------------------------------------
 
    Copyright 2014 Google Inc. All Rights Reserved.
+   Copyright 2016 Sergiusz Bazanski. All Rights Reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -20,5 +21,11 @@
 */
 #ifndef _NSJAIL_H
 #define _NSJAIL_H
+
+#ifdef _FORTIFY_SOURCE
+#undef _FORTIFY_SOURCE
+#endif              /* _FORTIFY_SOURCE */
+
+#define _FORTIFY_SOURCE 2
 
 #endif				/* _NSJAIL_H */


### PR DESCRIPTION
This lets us undefine any built-in gcc macro. Otherwise, a redefinition
from the command line occurs and a warning is thrown, breaking the build
(due to -Werror).