### PR TITLE
Kafel support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "kafel"]
+	path = kafel
+	url = https://github.com/google/kafel.git

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,11 @@ ifdef DEBUG
 	CFLAGS += -g -ggdb -gdwarf-4
 endif
 
+ifneq ("$(wildcard kafel/include/kafel.h)","")
+	CFLAGS += -I./kafel/include/ -DUSE_KAFEL
+	LIBS += kafel/libkafel.a
+endif
+
 ifeq ("$(wildcard /usr/include/libnl3/netlink/route/link/macvlan.h)","/usr/include/libnl3/netlink/route/link/macvlan.h")
 	CFLAGS += -DNSJAIL_NL3_WITH_MACVLAN -I/usr/include/libnl3
 	LDFLAGS += -lnl-3 -lnl-route-3
@@ -44,11 +49,19 @@ endif
 
 all: $(BIN)
 
-$(BIN): $(OBJS)
-	$(CC) -o $(BIN) $(OBJS) $(LDFLAGS)
+$(BIN): $(OBJS) $(LIBS)
+	$(CC) -o $(BIN) $(OBJS) $(LIBS) $(LDFLAGS)
+
+ifneq ("$(wildcard kafel/Makefile)","")
+kafel/libkafel.a:
+	$(MAKE) -C kafel
+endif
 
 clean:
 	$(RM) core Makefile.bak $(OBJS) $(BIN)
+ifneq ("$(wildcard kafel/Makefile)","")
+	$(MAKE) -C kafel clean
+endif
 
 depend:
 	makedepend -Y. -- -- $(SRCS)

--- a/common.h
+++ b/common.h
@@ -23,6 +23,7 @@
 #define NS_COMMON_H
 
 #include <limits.h>
+#include <linux/filter.h>
 #include <netinet/ip6.h>
 #include <stdbool.h>
 #include <sys/queue.h>
@@ -135,6 +136,7 @@ struct nsjconf_t {
 	const char *cgroup_mem_mount;
 	const char *cgroup_mem_parent;
 	size_t cgroup_mem_max;
+	struct sock_fprog seccomp_fprog;
 	 TAILQ_HEAD(envlist, charptr_t) envs;
 	 TAILQ_HEAD(pidslist, pids_t) pids;
 	 TAILQ_HEAD(mountptslist, mounts_t) mountpts;


### PR DESCRIPTION
Hi,

This patch adds support for Kafel library, which is an easier way to specify syscall filtering policies.

Best regards,
Wiktor