### PR TITLE
Don't try to open /proc/self/fd/2 as we might not have permission

### DIFF
--- a/log.c
+++ b/log.c
@@ -52,12 +52,13 @@ bool logInitLogFile(struct nsjconf_t *nsjconf, const char *logfile, bool is_verb
 		logfile = _LOG_DEFAULT_FILE;
 	}
 	if (logfile == NULL) {
-		logfile = "/proc/self/fd/2";
-	}
-	if (TEMP_FAILURE_RETRY(log_fd = open(logfile, O_CREAT | O_RDWR | O_APPEND, 0640)) == -1) {
 		log_fd = STDERR_FILENO;
-		PLOG_E("Couldn't open logfile open('%s')", logfile);
-		return false;
+	} else {
+		if (TEMP_FAILURE_RETRY(log_fd = open(logfile, O_CREAT | O_RDWR | O_APPEND, 0640)) == -1) {
+			log_fd = STDERR_FILENO;
+			PLOG_E("Couldn't open logfile open('%s')", logfile);
+			return false;
+		}
 	}
 	log_fd_isatty = (isatty(log_fd) == 1 ? true : false);
 	return true;


### PR DESCRIPTION
The terminal behind fd 2 might be owned by root and can't be opened by the user.
This happens e.g. if you ssh to a server as root and su to the user.