### PR TITLE
Option to skip chroot (for nested user namespaces)

### DIFF
--- a/common.h
+++ b/common.h
@@ -105,6 +105,7 @@ struct nsjconf_t {
 	bool daemonize;
 	time_t tlimit;
 	bool apply_sandbox;
+	bool pivot_root_only;
 	bool verbose;
 	bool keep_env;
 	bool keep_caps;

--- a/mount.c
+++ b/mount.c
@@ -219,6 +219,11 @@ static bool mountInitNsInternal(struct nsjconf_t *nsjconf)
 			PLOG_E("chroot('%s')", newrootdir);
 			return false;
 		}
+	} else {
+		if (rmdir("/old_root") == -1) {
+			PLOG_E("rmdir('/old_root')");
+			return false;
+		}
 	}
 
 	if (chdir(nsjconf->cwd) == -1) {

--- a/mount.c
+++ b/mount.c
@@ -190,10 +190,15 @@ static bool mountInitNsInternal(struct nsjconf_t *nsjconf)
 		return false;
 	}
 
-	const char *const newrootdir = "/new_root";
-	if (mkdir(newrootdir, 0755) == -1) {
-		PLOG_E("mkdir('%s')", newrootdir);
-		return false;
+	const char *newrootdir;
+	if (nsjconf->pivot_root_only == false) {
+		newrootdir = "/new_root";
+		if (mkdir(newrootdir, 0755) == -1) {
+			PLOG_E("mkdir('%s')", newrootdir);
+			return false;
+		}
+	} else {
+		newrootdir = "/";
 	}
 
 	struct mounts_t *p;
@@ -209,9 +214,11 @@ static bool mountInitNsInternal(struct nsjconf_t *nsjconf)
 		PLOG_E("umount2('/old_root', MNT_DETACH)");
 		return false;
 	}
-	if (chroot(newrootdir) == -1) {
-		PLOG_E("chroot('%s')", newrootdir);
-		return false;
+	if (nsjconf->pivot_root_only == false) {
+		if (chroot(newrootdir) == -1) {
+			PLOG_E("chroot('%s')", newrootdir);
+			return false;
+		}
 	}
 
 	if (chdir(nsjconf->cwd) == -1) {

--- a/mount.c
+++ b/mount.c
@@ -203,6 +203,12 @@ static bool mountInitNsInternal(struct nsjconf_t *nsjconf)
 
 	struct mounts_t *p;
 	TAILQ_FOREACH(p, &nsjconf->mountpts, pointers) {
+		// The intention behind pivot_root_only is to allow creating
+		// nested usernamespaces. If we bind mount over /, the kernel
+		// will see the process as chrooted and deny CLONE_NEWUSER.
+		if (nsjconf->pivot_root_only && strcmp(p->dst, "/") == 0) {
+			continue;
+		}
 		char dst[PATH_MAX];
 		snprintf(dst, sizeof(dst), "%s/%s", newrootdir, p->dst);
 		if (mountMount(nsjconf, p, "/old_root", dst) == false) {


### PR DESCRIPTION
The change introduces a new flag --pivot_root_only that, if set, will skip the chroot in mount.c.
This allows the process inside of nsjail to create new nested usernamespaces.