### PR TITLE
Simplify cloning/building.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM ubuntu
 
 RUN apt-get update && apt-get install gcc make git bison flex -y
 RUN git clone https://github.com/google/nsjail.git
-RUN cd /nsjail && git submodule update --init && cd kafel && make && cd .. && make
+RUN cd /nsjail && make
 RUN mv /nsjail/nsjail /bin && rm -rf -- /nsjail
 

--- a/Makefile
+++ b/Makefile
@@ -45,13 +45,20 @@ ifeq ($(USE_NL3), yes)
 endif
 endif
 
+.PHONY: all clear depend indent kafel
+
 .c.o: %.c
 	$(CC) $(CFLAGS) $< -o $@
 
-all: $(BIN)
+all: kafel $(BIN)
 
 $(BIN): $(OBJS) $(LIBS)
 	$(CC) -o $(BIN) $(OBJS) $(LIBS) $(LDFLAGS)
+
+kafel:
+ifeq ("$(wildcard kafel/Makefile)","")
+	git submodule update --init
+endif
 
 kafel/libkafel.a:
 	$(MAKE) -C kafel


### PR DESCRIPTION
Kafel submodule will be automatically initialized if not done manually before invoking `make`.

Just 2 commands needed now:
$ git clone https://github.com/google/nsjail.git
$ make -C nsjail