### PR TITLE
Fix Dockerfile to make it built with current Makefile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu
 
-RUN apt-get update && apt-get install gcc make git bison flex -y
+RUN apt-get -y update
+RUN apt-get -y install autoconf bison check flex gcc git libtool make pkg-config protobuf-c-compiler re2c
 RUN git clone https://github.com/google/nsjail.git
 RUN cd /nsjail && make
 RUN mv /nsjail/nsjail /bin && rm -rf -- /nsjail

--- a/README.md
+++ b/README.md
@@ -476,5 +476,5 @@ This will build up an image containing njsail and kafel.
 
 From now you can either use it in another Dockerfile (`FROM nsjail`) or directly:
 <pre>
-docker run --rm -it nsjail nsjail --user 99999 --group 99999 --disable_proc --chroot / --time_limit 30 /bin/bash
+docker run --privileged --rm -it nsjail nsjail --user 99999 --group 99999 --disable_proc --chroot / --time_limit 30 /bin/bash
 </pre>


### PR DESCRIPTION
To build the latest nsjail in docker, I think several packages are missing.
Let me update Dockerfile to install such packages.

Also, let me do some clean up.
- update and install become different lines.
- move -y to the beginning.
- make installed packages alphabetical order.