### PR TITLE
Add an --exec_file argument to allow argv[0] to differ from the binary being exec'd.

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -66,6 +66,7 @@ struct custom_option custom_opts[] = {
      "\tr: Immediately launch a single process on the console, keep doing it "
      "forever [MODE_STANDALONE_RERUN]"},
     {{"config", required_argument, NULL, 'C'}, "Configuration file in the config.proto ProtoBuf format"},
+    {{"exec_file", required_argument, NULL, 'x'}, "File to exec (default: argv[0])"},
     {{"chroot", required_argument, NULL, 'c'}, "Directory containing / of the jail (default: none)"},
     {{"rw", no_argument, NULL, 0x601}, "Mount / and /proc as RW (default: RO)"},
     {{"user", required_argument, NULL, 'u'}, "Username/uid of processess inside the jail (default: your current uid). You can also use inside_ns_uid:outside_ns_uid:count convention here. Can be specified multiple times"},
@@ -300,6 +301,7 @@ bool cmdlineParse(int argc, char *argv[], struct nsjconf_t * nsjconf)
 {
   /*  *INDENT-OFF* */
   (*nsjconf) = (const struct nsjconf_t){
+      .exec_file = NULL,
       .hostname = "NSJAIL",
       .cwd = "/",
       .chroot = NULL,
@@ -386,12 +388,15 @@ bool cmdlineParse(int argc, char *argv[], struct nsjconf_t * nsjconf)
 	int opt_index = 0;
 	for (;;) {
 		int c = getopt_long(argc, argv,
-				    "H:D:C:c:p:i:u:g:l:t:M:Ndvqeh?E:R:B:T:P:I:U:G:", opts,
+				    "x:H:D:C:c:p:i:u:g:l:t:M:Ndvqeh?E:R:B:T:P:I:U:G:", opts,
 				    &opt_index);
 		if (c == -1) {
 			break;
 		}
 		switch (c) {
+		case 'x':
+			nsjconf->exec_file = optarg;
+			break;
 		case 'H':
 			nsjconf->hostname = optarg;
 			break;
@@ -783,6 +788,9 @@ bool cmdlineParse(int argc, char *argv[], struct nsjconf_t * nsjconf)
 		LOG_E("No command provided");
 		cmdlineUsage(argv[0]);
 		return false;
+	}
+	if (nsjconf->exec_file == NULL) {
+		nsjconf->exec_file = nsjconf->argv[0];
 	}
 
 	return true;

--- a/common.h
+++ b/common.h
@@ -113,6 +113,7 @@ enum llevel_t {
 };
 
 struct nsjconf_t {
+	const char *exec_file;
 	const char *hostname;
 	const char *cwd;
 	char *const *argv;

--- a/config.c
+++ b/config.c
@@ -232,6 +232,7 @@ static bool configParseInternal(struct nsjconf_t *nsjconf, Nsjail__NsJailConfig 
 			argv[i + 1] = utilStrDup(njc->exec_bin->arg[i]);
 		}
 		argv[njc->exec_bin->n_arg + 1] = NULL;
+		nsjconf->exec_file = argv[0];
 		nsjconf->argv = argv;
 	}
 

--- a/subproc.c
+++ b/subproc.c
@@ -165,7 +165,7 @@ static int subprocNewProc(struct nsjconf_t *nsjconf, int fd_in, int fd_out, int 
 
 	char cs_addr[64];
 	netConnToText(fd_in, true /* remote */ , cs_addr, sizeof(cs_addr), NULL);
-	LOG_I("Executing '%s' for '%s'", nsjconf->argv[0], cs_addr);
+	LOG_I("Executing '%s' for '%s'", nsjconf->exec_file, cs_addr);
 
 	for (size_t i = 0; nsjconf->argv[i]; i++) {
 		LOG_D(" Arg[%zu]: '%s'", i, nsjconf->argv[i]);
@@ -175,9 +175,9 @@ static int subprocNewProc(struct nsjconf_t *nsjconf, int fd_in, int fd_out, int 
 	if (sandboxApply(nsjconf) == false) {
 		exit(1);
 	}
-	execv(nsjconf->argv[0], &nsjconf->argv[0]);
+	execv(nsjconf->exec_file, &nsjconf->argv[0]);
 
-	PLOG_E("execve('%s') failed", nsjconf->argv[0]);
+	PLOG_E("execve('%s') failed", nsjconf->exec_file);
 
 	_exit(1);
 }


### PR DESCRIPTION
This is a bit of a niche use case, but sometimes I don't want the binary's argv[0] to be the binary's name.

Hopefully this change isn't too contentious. I wasn't sure about specifying an extra setting in the protobuf, but let me know if you would like one.