### PR TITLE
Add an extra log_fd argument to specify an FD to log to.

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -76,7 +76,8 @@ struct custom_option custom_opts[] = {
     {{"port", required_argument, NULL, 'p'}, "TCP port to bind to (enables MODE_LISTEN_TCP) (default: 0)"},
     {{"bindhost", required_argument, NULL, 0x604}, "IP address port to bind to (only in [MODE_LISTEN_TCP]), '::ffff:127.0.0.1' for locahost (default: '::')"},
     {{"max_conns_per_ip", required_argument, NULL, 'i'}, "Maximum number of connections per one IP (only in [MODE_LISTEN_TCP]), (default: 0 (unlimited))"},
-    {{"log", required_argument, NULL, 'l'}, "Log file (default: /proc/self/fd/2)"},
+    {{"log", required_argument, NULL, 'l'}, "Log file (default: use log_fd)"},
+    {{"log_fd", required_argument, NULL, 'L'}, "Log FD (default: 2)"},
     {{"time_limit", required_argument, NULL, 't'}, "Maximum time that a jail can exist, in seconds (default: 600)"},
     {{"daemon", no_argument, NULL, 'd'}, "Daemonize after start"},
     {{"verbose", no_argument, NULL, 'v'}, "Verbose output"},
@@ -308,6 +309,7 @@ bool cmdlineParse(int argc, char *argv[], struct nsjconf_t * nsjconf)
       .argv = NULL,
       .port = 0,
       .bindhost = "::",
+      .log_fd = 2,
       .logfile = NULL,
       .loglevel = INFO,
       .daemonize = false,
@@ -388,7 +390,7 @@ bool cmdlineParse(int argc, char *argv[], struct nsjconf_t * nsjconf)
 	int opt_index = 0;
 	for (;;) {
 		int c = getopt_long(argc, argv,
-				    "x:H:D:C:c:p:i:u:g:l:t:M:Ndvqeh?E:R:B:T:P:I:U:G:", opts,
+				    "x:H:D:C:c:p:i:u:g:l:L:t:M:Ndvqeh?E:R:B:T:P:I:U:G:", opts,
 				    &opt_index);
 		if (c == -1) {
 			break;
@@ -423,6 +425,12 @@ bool cmdlineParse(int argc, char *argv[], struct nsjconf_t * nsjconf)
 			break;
 		case 'l':
 			nsjconf->logfile = optarg;
+			if (logInitLogFile(nsjconf) == false) {
+				return false;
+			}
+			break;
+		case 'L':
+			nsjconf->log_fd = strtol(optarg, NULL, 0);
 			if (logInitLogFile(nsjconf) == false) {
 				return false;
 			}

--- a/common.h
+++ b/common.h
@@ -119,6 +119,7 @@ struct nsjconf_t {
 	char *const *argv;
 	int port;
 	const char *bindhost;
+	int log_fd;
 	const char *logfile;
 	enum llevel_t loglevel;
 	bool daemonize;

--- a/config.c
+++ b/config.c
@@ -69,6 +69,7 @@ static bool configParseInternal(struct nsjconf_t *nsjconf, Nsjail__NsJailConfig 
 	nsjconf->tlimit = njc->time_limit;
 	nsjconf->daemonize = njc->daemon;
 
+	nsjconf->log_fd = njc->log_fd;
 	nsjconf->logfile = utilStrDup(njc->log_file);
 	if (njc->has_log_level) {
 		switch (njc->log_level) {

--- a/config.proto
+++ b/config.proto
@@ -88,6 +88,8 @@ message NsJailConfig
     /* Should nsjail go into background? */
     required bool daemon = 14 [ default = false ];
 
+    /* FD to log to. */
+    required int32 log_fd = 61 [ default = 2 ];
     /* File to save lofs to */
     optional string log_file = 15;
     /* Minimum log level displayed.

--- a/log.c
+++ b/log.c
@@ -51,7 +51,9 @@ bool logInitLogFile(struct nsjconf_t *nsjconf)
 		close(log_fd);
 		log_fd = STDERR_FILENO;
 	}
+	log_fd = nsjconf->log_fd;
 	log_level = nsjconf->loglevel;
+
 	if (nsjconf->logfile == NULL && nsjconf->daemonize == true) {
 		nsjconf->logfile = _LOG_DEFAULT_FILE;
 	}


### PR DESCRIPTION
(this patch is crazy, but so is systemd so bear with me)

In some situations, setting --log to /proc/self/fd/# is not sufficient to log out to a different FD. For instance, if a master process passes its stderr to the child nsjail process as fd 3, the nsjail child may not always be able to log to /proc/self/fd/3, e.g. if the master process is running under systemd, whose /proc/self/fd/2 is actually a socket and not a pipe. However, having nsjail write to fd 3 directly is fine and there's no other good way to handle this situation.