### PR TITLE
Refactor using current official Dockerfile best practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,21 @@
-FROM ubuntu
+FROM ubuntu:16.04
 
-RUN apt-get -y update
-RUN apt-get -y install autoconf bison check flex gcc git libtool make pkg-config protobuf-c-compiler re2c
+RUN apt-get -y update && apt-get install -y \
+    autoconf \
+    bison \
+    check \
+    flex \
+    gcc \
+    git \
+    libtool \
+    make \
+    pkg-config \
+    protobuf-c-compiler \
+    re2c \
+&& rm -rf /var/lib/apt/lists/*
+
 RUN git clone https://github.com/google/nsjail.git
-RUN cd /nsjail && make
-RUN mv /nsjail/nsjail /bin && rm -rf -- /nsjail
 
+WORKDIR /nsjail
+
+RUN make && mv /nsjail/nsjail /bin && rm -rf -- /nsjail


### PR DESCRIPTION
Implement best practices for Dockerfiles as per the official
documentation:
https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/

Reduces image size from 451.6MB to 404.9MB.