### PR TITLE
Add back ERRNO(1337) for example config

### DIFF
--- a/configs/bash-with-fake-geteuid.cfg
+++ b/configs/bash-with-fake-geteuid.cfg
@@ -169,6 +169,7 @@ mount {
 
 seccomp_string: "
 	POLICY example {
+		ERRNO(1337) { geteuid },
 		KILL { syslog },
 		ERRNO(0) { ptrace }
 	}


### PR DESCRIPTION
The error code 1337 seems to have been removed accidentally in the file `configs/bash-with-fake-geteuid.cfg`. It turns out to be inconsistent with the description: 

> ... Also, __NR_geteuid returns -1337 value, which /usr/bin/id will show as euid=4294965959. ...

This commit adds it back.