### PR TITLE
Fix dockerfile: add libcap-dev install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get -y update && apt-get install -y \
     pkg-config \
     protobuf-c-compiler \
     re2c \
-&& rm -rf /var/lib/apt/lists/*
+    libcap-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/google/nsjail.git
 


### PR DESCRIPTION
Before the fix the build ends up somewhere with:
> sys/capability.h: No such file or directory