### PR TITLE
Adding the mistakenly removed line to the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,4 +113,5 @@ user.o: user.h common.h log.h subproc.h util.h
 util.o: util.h common.h log.h
 uts.o: uts.h common.h log.h
 cpu.o: cpu.h common.h log.h util.h
-config.o: common.h caps.h config.h log.h mount.h user.h util.h
+config.o: common.h caps.h config.h log.h mount.h user.h util.h config.pb.h
+config.pb.o: config.pb.h


### PR DESCRIPTION
I reverted one of the changes as it caused the following error on Ubuntu 16.04:
```
g++ -O2 -c -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -Wformat -Wformat=2 -Wformat-security -fPIE -Wno-format-nonliteral -Wall -Wextra -Werror -Ikafel/include -pthread -I/usr/local/include -std=c++11 -Wno-unused -Wno-unused-parameter config.cc -o config.o
config.cc:45:23: fatal error: config.pb.h: No such file or directory
compilation terminated.
Makefile:66: recipe for target 'config.o' failed
make: *** [config.o] Error 1
```