### PR TITLE
manpage: tweak for recent options changes

### DIFF
--- a/nsjail.1
+++ b/nsjail.1
@@ -79,7 +79,10 @@ Daemonize after start
 Verbose output
 .TP
 \fB\-\-quiet\fR|\fB\-q\fR
-Only output warning and more important messages
+Log warning and more important messages only
+.TP
+\fB\-\-realy_quiet\fR|\fB\-Q\fR
+Log fatal messages only
 .TP
 \fB\-\-keep_env\fR|\fB\-e\fR
 Should all environment variables be passed to the child?
@@ -106,25 +109,25 @@ Don't set the prctl(NO_NEW_PRIVS, 1) (DANGEROUS)
 Retain this capability in local namespace (e.g. CAP_PTRACE). Can be specified multiple times
 .TP
 \fB\-\-rlimit_as\fR VALUE
-RLIMIT_AS in MB, 'max' for RLIM_INFINITY, 'def' for the current value (default: 512)
+RLIMIT_AS in MB, 'max' or 'hard' for the current hard limit, 'def' or 'soft' for the current soft limit, 'inf' for RLIM_INFINITY (default: 512)
 .TP
 \fB\-\-rlimit_core\fR VALUE
-RLIMIT_CORE in MB, 'max' for RLIM_INFINITY, 'def' for the current value (default: 0)
+RLIMIT_CORE in MB, 'max' or 'hard' for the current hard limit, 'def' or 'soft' for the current limit, 'inf' for RLIM_INFINITY (default: 0)
 .TP
 \fB\-\-rlimit_cpu\fR VALUE
-RLIMIT_CPU, 'max' for RLIM_INFINITY, 'def' for the current value (default: 600)
+RLIMIT_CPU, 'max' or 'hard' for the current hard limit, 'def' or 'soft' for the current soft limit, 'inf' for RLIM_INFINITY (default: 600)
 .TP
 \fB\-\-rlimit_fsize\fR VALUE
-RLIMIT_FSIZE in MB, 'max' for RLIM_INFINITY, 'def' for the current value (default: 1)
+RLIMIT_FSIZE in MB, 'max' or 'hard' for the current hard limit, 'def' or 'soft' for the current soft limit, 'inf' for RLIM_INFINITY (default: 1)
 .TP
 \fB\-\-rlimit_nofile\fR VALUE
-RLIMIT_NOFILE, 'max' for RLIM_INFINITY, 'def' for the current value (default: 32)
+RLIMIT_NOFILE, 'max' or 'hard' for the current hard limit, 'def' or 'soft' for the current limit, 'inf' for RLIM_INFINITY (default: 32)
 .TP
 \fB\-\-rlimit_nproc\fR VALUE
-RLIMIT_NPROC, 'max' for RLIM_INFINITY, 'def' for the current value (default: 'def')
+RLIMIT_NPROC, 'max' or 'hard' for the current hard limit, 'def' or 'soft' for the current soft limit, 'inf' for RLIM_INFINITY (default: 'soft')
 .TP
 \fB\-\-rlimit_stack\fR VALUE
-RLIMIT_STACK in MB, 'max' for RLIM_INFINITY, 'def' for the current value (default: 'def')
+RLIMIT_STACK in MB, 'max' or 'hard' for the current hard limit, 'def' or 'soft' for the current soft limit, 'inf' for RLIM_INFINITY (default: 'soft')
 .TP
 \fB\-\-persona_addr_compat_layout\fR
 personality(ADDR_COMPAT_LAYOUT)
@@ -257,15 +260,3 @@ Execute echo command directly, without a supervising process:
 .IP
 nsjail \-Me \-\-chroot / \-\-disable_proc \-\- /bin/echo "ABC"
 \"
-.SH SEE ALSO
-The full documentation for
-.B nsjail
-is maintained as a Texinfo manual.  If the
-.B info
-and
-.B nsjail
-programs are properly installed at your site, the command
-.IP
-.B info nsjail
-.PP
-should give you access to the complete manual.


### PR DESCRIPTION
Adjust rlimit_* options to match command line --help output.
Add --really_quiet option.

And some clean up:
Remove 'See Also' section that only references a non-existent
info page that is a relic of using help2man for initial manual
page generation.