### PR TITLE
Revert "caps: define CAP_AUDIT_READ if not defined"

### DIFF
--- a/caps.c
+++ b/caps.c
@@ -31,10 +31,6 @@
 #include "log.h"
 #include "util.h"
 
-#if !defined(CAP_AUDIT_READ)
-#define CAP_AUDIT_READ 37
-#endif /* !defined(CAP_AUDIT_READ) */
-
 static struct {
 	const int val;
 	const char* const name;
@@ -76,7 +72,9 @@ static struct {
 	NS_VALSTR_STRUCT(CAP_SYSLOG),
 	NS_VALSTR_STRUCT(CAP_WAKE_ALARM),
 	NS_VALSTR_STRUCT(CAP_BLOCK_SUSPEND),
+#if defined(CAP_AUDIT_READ)
 	NS_VALSTR_STRUCT(CAP_AUDIT_READ),
+#endif /* defined(CAP_AUDIT_READ) */
 };
 
 int capsNameToVal(const char* name)


### PR DESCRIPTION
Restore compatibility with 3.x kernels by not requiring CAP_AUDIT_READ
if not defined in kernel header file

This reverts commit 7820553cb9296b5f1a3137153948db45309aa6b1.

Conflicts:
	caps.c
	contain.h