### PR TITLE
align stack for child process

### DIFF
--- a/subproc.c
+++ b/subproc.c
@@ -378,7 +378,7 @@ static bool subprocInitParent(struct nsjconf_t* nsjconf, pid_t pid, int pipefd)
 }
 
 /* Will be used inside the child process only, so it's save to have it in BSS */
-static uint8_t subprocCloneStack[128 * 1024]; /* 128 KiB */
+static uint8_t subprocCloneStack[128 * 1024] __attribute__(( aligned(__BIGGEST_ALIGNMENT__ ))); /* 128 KiB */
 /* Cannot be on the stack, as the child's stack pointer will change after clone() */
 static __thread jmp_buf env;
 


### PR DESCRIPTION
Fixes "bus error" crashes on aarch64 caused by alignment faults.

On aarch64, the stack pointer needs to be 16-byte aligned; use gcc
builtin macro `__BIGGEST_ALIGNMENT__` to specify a stack alignment
suitable for each platform.