### PR TITLE
Support cgroup net_cls subsystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,12 @@ Options:
 	Location of pids cgroup FS (default: '/sys/fs/cgroup/pids')
  --cgroup_pids_parent VALUE
 	Which pre-existing pids cgroup to use as a parent (default: 'NSJAIL')
+ --cgroup_net_cls_classid VALUE
+	Class identifier of network packets in the group (default: '0' - disabled)
+ --cgroup_net_cls_mount VALUE
+	Location of net_cls cgroup FS (default: '/sys/fs/cgroup/net_cls')
+ --cgroup_net_cls_parent VALUE
+	Which pre-existing net_cls cgroup to use as a parent (default: 'NSJAIL')
  --iface_no_lo 
 	Don't bring up the 'lo' interface
  --macvlan_iface|-I VALUE

--- a/cmdline.c
+++ b/cmdline.c
@@ -127,6 +127,9 @@ struct custom_option custom_opts[] = {
     { { "cgroup_pids_max", required_argument, NULL, 0x0811 }, "Maximum number of pids in a cgroup (default: '0' - disabled)" },
     { { "cgroup_pids_mount", required_argument, NULL, 0x0812 }, "Location of pids cgroup FS (default: '/sys/fs/cgroup/pids')" },
     { { "cgroup_pids_parent", required_argument, NULL, 0x0813 }, "Which pre-existing pids cgroup to use as a parent (default: 'NSJAIL')" },
+    { { "cgroup_net_cls_classid", required_argument, NULL, 0x0821 }, "Class identifier of network packets in the group (default: '0' - disabled)" },
+    { { "cgroup_net_cls_mount", required_argument, NULL, 0x0822 }, "Location of net_cls cgroup FS (default: '/sys/fs/cgroup/net_cls')" },
+    { { "cgroup_net_cls_parent", required_argument, NULL, 0x0823 }, "Which pre-existing net_cls cgroup to use as a parent (default: 'NSJAIL')" },
     { { "iface_no_lo", no_argument, NULL, 0x700 }, "Don't bring the 'lo' interface up" },
     { { "macvlan_iface", required_argument, NULL, 'I' }, "Interface which will be cloned (MACVLAN) and put inside the subprocess' namespace as 'vs'" },
     { { "macvlan_vs_ip", required_argument, NULL, 0x701 }, "IP of the 'vs' interface (e.g. \"192.168.0.1\")" },
@@ -361,6 +364,9 @@ bool cmdlineParse(int argc, char* argv[], struct nsjconf_t* nsjconf)
 		.cgroup_pids_mount = "/sys/fs/cgroup/pids",
 		.cgroup_pids_parent = "NSJAIL",
 		.cgroup_pids_max = (size_t)0,
+		.cgroup_net_cls_mount = "/sys/fs/cgroup/net_cls",
+		.cgroup_net_cls_parent = "NSJAIL",
+		.cgroup_net_cls_classid = (unsigned int)0,
 		.iface_no_lo = false,
 		.iface_vs = NULL,
 		.iface_vs_ip = "0.0.0.0",
@@ -731,6 +737,15 @@ bool cmdlineParse(int argc, char* argv[], struct nsjconf_t* nsjconf)
 			break;
 		case 0x813:
 			nsjconf->cgroup_pids_parent = optarg;
+			break;
+		case 0x821:
+			nsjconf->cgroup_net_cls_classid = (unsigned int)strtoul(optarg, NULL, 0);
+			break;
+		case 0x822:
+			nsjconf->cgroup_net_cls_mount = optarg;
+			break;
+		case 0x823:
+			nsjconf->cgroup_net_cls_parent = optarg;
 			break;
 		case 'P':
 			if ((nsjconf->kafel_file = fopen(optarg, "r")) == NULL) {

--- a/config.cc
+++ b/config.cc
@@ -276,6 +276,9 @@ static bool configParseInternal(struct nsjconf_t* nsjconf, const nsjail::NsJailC
 	nsjconf->cgroup_pids_max = njc.cgroup_pids_max();
 	nsjconf->cgroup_pids_mount = njc.cgroup_pids_mount().c_str();
 	nsjconf->cgroup_pids_parent = njc.cgroup_pids_parent().c_str();
+	nsjconf->cgroup_net_cls_classid = njc.cgroup_net_cls_classid();
+	nsjconf->cgroup_net_cls_mount = njc.cgroup_net_cls_mount().c_str();
+	nsjconf->cgroup_net_cls_parent = njc.cgroup_net_cls_parent().c_str();
 
 	nsjconf->iface_no_lo = njc.iface_no_lo();
 	nsjconf->iface_vs = DUP_IF_SET(njc, macvlan_iface);

--- a/config.proto
+++ b/config.proto
@@ -213,4 +213,11 @@ message NsJailConfig
     /* Binary path (with arguments) to be executed. If not specified here, it
        can be specified with cmd-line as "-- /path/to/command arg1 arg2" */
     optional Exe exec_bin = 70;
+
+    /* If > 0, Class identifier of network packets inside jail */
+    optional uint32 cgroup_net_cls_classid = 71 [ default = 0 ];
+    /* Mount point for cgroups-net-cls in your system */
+    optional string cgroup_net_cls_mount = 72 [ default = "/sys/fs/cgroup/net_cls" ];
+    /* Writeable directory (for the nsjail user) under cgroup_net_mount */
+    optional string cgroup_net_cls_parent = 73 [ default = "NSJAIL" ];
 }

--- a/nsjail.1
+++ b/nsjail.1
@@ -220,6 +220,15 @@ Location of pids cgroup FS (default: '/sys/fs/cgroup/pids')
 \fB\-\-cgroup_pids_parent\fR VALUE
 Which pre\-existing pids cgroup to use as a parent (default: 'NSJAIL')
 .TP
+\fB\-\-cgroup_net_cls_classid\fR VALUE
+Class identifier of network packets in the group (default: '0' \- disabled)
+.TP
+\fB\-\-cgroup_net_cls_mount\fR VALUE
+Location of net_cls cgroup FS (default: '/sys/fs/cgroup/net_cls')
+.TP
+\fB\-\-cgroup_net_cls_parent\fR VALUE
+Which pre\-existing net_cls cgroup to use as a parent (default: 'NSJAIL')
+.TP
 \fB\-\-iface_no_lo\fR
 Don't bring up the 'lo' interface
 .TP

--- a/nsjail.h
+++ b/nsjail.h
@@ -158,6 +158,9 @@ struct nsjconf_t {
 	const char* cgroup_pids_mount;
 	const char* cgroup_pids_parent;
 	size_t cgroup_pids_max;
+	const char* cgroup_net_cls_mount;
+	const char* cgroup_net_cls_parent;
+	unsigned int cgroup_net_cls_classid;
 	FILE* kafel_file;
 	char* kafel_string;
 	long num_cpus;


### PR DESCRIPTION
Hi,

This patch adds support for cgroup's net_cls subsystem.

We can set class identifiers to network packets that occurred  in the jail and use it for traffic control and filtering.

Best regards,