### PR TITLE
Remove redundant check if UTS namespace is enabled

### DIFF
--- a/uts.c
+++ b/uts.c
@@ -32,9 +32,6 @@ bool utsInitNs(struct nsjconf_t* nsjconf) {
 	}
 
 	LOG_D("Setting hostname to '%s'", nsjconf->hostname);
-	if (nsjconf->clone_newuts == false) {
-		return true;
-	}
 	if (sethostname(nsjconf->hostname, strlen(nsjconf->hostname)) == -1) {
 		PLOG_E("sethostname('%s')", nsjconf->hostname);
 		return false;


### PR DESCRIPTION
While analyzing source code I noticed that for UTS namespace is performed twice, before and after log statement.