### PR TITLE
nsjail.1: update for new options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,8 @@ Options:
 	Configuration file in the config.proto ProtoBuf format
  --exec_file|-x VALUE
 	File to exec (default: argv[0])
+ --execute_fd
+	Use execveat() to execute a file-descriptor instead of executing the binary path. In such case argv[0]/exec_file denotes a file path before mount namespacing
  --chroot|-c VALUE
 	Directory containing / of the jail (default: none)
  --rw 
@@ -374,6 +376,8 @@ Options:
 	Log FD (default: 2)
  --time_limit|-t VALUE
 	Maximum time that a jail can exist, in seconds (default: 600)
+ --max_cpus VALUE
+	Maximum number of CPUs a single jailed process can use (default: 0 'no limit')
  --daemon|-d 
 	Daemonize after start
  --verbose|-v 
@@ -386,6 +390,8 @@ Options:
 	Environment variable (can be used multiple times)
  --keep_caps 
 	Don't drop capabilities (DANGEROUS)
+ --cap VALUE
+	Retain this capability in local namespace (e.g. CAP_PTRACE). Can be specified multiple times.
  --silent 
 	Redirect child's fd:0/1/2 to /dev/null
  --skip_setsid 
@@ -444,8 +450,14 @@ Options:
 	List of mountpoints to be mounted as RW/tmpfs inside the container. Can be specified multiple times. Supports 'dest' syntax
  --tmpfs_size VALUE
 	Number of bytes to allocate for tmpfsmounts (default: 4194304)
+ --mount|-m VALUE
+	Arbitrary mount, format src:dst:fs_type:options
  --disable_proc 
 	Disable mounting /proc in the jail
+ --proc_path VALUE
+	Path used to mount procfs (default: '/proc')
+ --proc_rw
+	Is procfs mount as R/W (default: R/O)
  --seccomp_policy|-P VALUE
 	Path to file containing seccomp-bpf policy (see kafel/)
  --seccomp_string VALUE
@@ -468,6 +480,12 @@ Options:
 	Location of net_cls cgroup FS (default: '/sys/fs/cgroup/net_cls')
  --cgroup_net_cls_parent VALUE
 	Which pre-existing net_cls cgroup to use as a parent (default: 'NSJAIL')
+ --cgroup_cpu_ms_per_sec VALUE
+	Number of us that the process group can use per second (default: '0' - disabled)
+ --cpu_mount VALUE
+	Location of cpu cgroup FS (default: '/sys/fs/cgroup/net_cls')
+ --cpu_parent VALUE
+	Which pre-existing cpu cgroup to use as a parent (default: 'NSJAIL')
  --iface_no_lo 
 	Don't bring up the 'lo' interface
  --macvlan_iface|-I VALUE

--- a/nsjail.1
+++ b/nsjail.1
@@ -97,6 +97,9 @@ Environment variable (can be used multiple times)
 \fB\-\-keep_caps\fR
 Don't drop capabilities in the local namespace
 .TP
+\fB\-\-cap\fR VALUE
+Retain this capability in local namespace (e.g. CAP_PTRACE). Can be specified multiple times
+.TP
 \fB\-\-silent\fR
 Redirect child's fd:0/1/2 to /dev/null
 .TP
@@ -108,9 +111,6 @@ Don't close this FD before executing child (can be specified multiple times), by
 .TP
 \fB\-\-disable_no_new_privs\fR
 Don't set the prctl(NO_NEW_PRIVS, 1) (DANGEROUS)
-.TP
-\fB\-\-cap\fR VALUE
-Retain this capability in local namespace (e.g. CAP_PTRACE). Can be specified multiple times
 .TP
 \fB\-\-rlimit_as\fR VALUE
 RLIMIT_AS in MB, 'max' or 'hard' for the current hard limit, 'def' or 'soft' for the current soft limit, 'inf' for RLIM_INFINITY (default: 512)
@@ -187,6 +187,9 @@ List of mountpoints to be mounted as RW/tmpfs inside the container. Can be speci
 \fB\-\-tmpfs_size\fR VALUE
 Number of bytes to allocate for tmpfsmounts (default: 4194304)
 .TP
+\fB\-\-mount\fR|\fB\-m\fR VALUE
+Arbitrary mount, format src:dst:fs_type:options
+.TP
 \fB\-\-disable_proc\fR
 Disable mounting \fI/proc\fP in the jail
 .TP
@@ -228,6 +231,15 @@ Location of net_cls cgroup FS (default: '/sys/fs/cgroup/net_cls')
 .TP
 \fB\-\-cgroup_net_cls_parent\fR VALUE
 Which pre\-existing net_cls cgroup to use as a parent (default: 'NSJAIL')
+.TP
+\fB\-\-cgroup_cpu_ms_per_sec\fR VALUE
+Number of us that the process group can use per second (default: '0' - disabled)
+.TP
+\fB\-\-cpu_mount\fR VALUE
+Location of cpu cgroup FS (default: '/sys/fs/cgroup/net_cls')
+.TP
+\fB\-\-cpu_parent\fR VALUE
+Which pre-existing cpu cgroup to use as a parent (default: 'NSJAIL')
 .TP
 \fB\-\-iface_no_lo\fR
 Don't bring up the 'lo' interface


### PR DESCRIPTION
Also, move the --cap option description so that it follows the --keep-caps option, which matches the --help output and seems logical.