### PR TITLE
Added --macvlan_vs_ma switch to be able to set macvlan's mac-address.

### DIFF
--- a/cmdline.cc
+++ b/cmdline.cc
@@ -151,6 +151,7 @@ struct custom_option custom_opts[] = {
     { { "macvlan_vs_ip", required_argument, NULL, 0x701 }, "IP of the 'vs' interface (e.g. \"192.168.0.1\")" },
     { { "macvlan_vs_nm", required_argument, NULL, 0x702 }, "Netmask of the 'vs' interface (e.g. \"255.255.255.0\")" },
     { { "macvlan_vs_gw", required_argument, NULL, 0x703 }, "Default GW for the 'vs' interface (e.g. \"192.168.0.1\")" },
+    { { "macvlan_vs_ma", required_argument, NULL, 0x705 }, "Mac-address of the 'vs' interface (e.g. \"ba:ad:ba:be:45:00\")" },
 };
 // clang-format on
 
@@ -417,6 +418,7 @@ std::unique_ptr<nsjconf_t> parseArgs(int argc, char* argv[]) {
 	nsjconf->iface_vs_ip = "0.0.0.0";
 	nsjconf->iface_vs_nm = "255.255.255.0";
 	nsjconf->iface_vs_gw = "0.0.0.0";
+	nsjconf->iface_vs_ma = "";
 	nsjconf->orig_uid = getuid();
 	nsjconf->num_cpus = sysconf(_SC_NPROCESSORS_ONLN);
 	nsjconf->seccomp_fprog.filter = NULL;
@@ -759,6 +761,9 @@ std::unique_ptr<nsjconf_t> parseArgs(int argc, char* argv[]) {
 			break;
 		case 0x704:
 			nsjconf->ifaces.push_back(optarg);
+			break;
+		case 0x705:
+			nsjconf->iface_vs_ma = optarg;
 			break;
 		case 0x801:
 			nsjconf->cgroup_mem_max = (size_t)strtoull(optarg, NULL, 0);

--- a/config.cc
+++ b/config.cc
@@ -262,6 +262,7 @@ static bool configParseInternal(nsjconf_t* nsjconf, const nsjail::NsJailConfig& 
 	nsjconf->iface_vs_ip = njc.macvlan_vs_ip();
 	nsjconf->iface_vs_nm = njc.macvlan_vs_nm();
 	nsjconf->iface_vs_gw = njc.macvlan_vs_gw();
+	nsjconf->iface_vs_ma = njc.macvlan_vs_ma();
 
 	if (njc.has_exec_bin()) {
 		nsjconf->exec_file = njc.exec_bin().path();

--- a/config.proto
+++ b/config.proto
@@ -234,6 +234,7 @@ message NsJailConfig {
     optional string macvlan_vs_ip = 73 [default = "192.168.0.2"];
     optional string macvlan_vs_nm = 74 [default = "255.255.255.0"];
     optional string macvlan_vs_gw = 75 [default = "192.168.0.1"];
+    optional string macvlan_vs_ma = 80 [default = "ba:ad:ba:be:45:00"];
 
     /* Binary path (with arguments) to be executed. If not specified here, it
        can be specified with cmd-line as "-- /path/to/command arg1 arg2" */

--- a/net.cc
+++ b/net.cc
@@ -187,13 +187,21 @@ bool initNsFromParent(nsjconf_t* nsjconf, int pid) {
 	LOG_D("Putting iface:'%s' into namespace of PID:%d (with /sbin/ip)",
 	    nsjconf->iface_vs.c_str(), pid);
 
-	const std::vector<std::string> argv{"/sbin/ip", "link", "add", "link", nsjconf->iface_vs,
-	    "name", IFACE_NAME, "netns", std::to_string(pid), "type", "macvlan", "mode", "bridge"};
-	if (subproc::systemExe(argv, environ) != 0) {
-		LOG_E("Couldn't create MACVTAP interface for '%s'", nsjconf->iface_vs.c_str());
-		return false;
+	if ( nsjconf->iface_vs_ma != "" ) {
+	  const std::vector<std::string> argv{"/sbin/ip", "link", "add", "link", nsjconf->iface_vs,
+	      "name", IFACE_NAME, "netns", std::to_string(pid), "address", nsjconf->iface_vs_ma, "type", "macvlan", "mode", "bridge"};
+	  if (subproc::systemExe(argv, environ) != 0) {
+	    LOG_E("Couldn't create MACVTAP interface for '%s'", nsjconf->iface_vs.c_str());
+	    return false;
+	  }
+	} else {
+	  const std::vector<std::string> argv{"/sbin/ip", "link", "add", "link", nsjconf->iface_vs,
+	      "name", IFACE_NAME, "netns", std::to_string(pid), "type", "macvlan", "mode", "bridge"};
+	  if (subproc::systemExe(argv, environ) != 0) {
+	    LOG_E("Couldn't create MACVTAP interface for '%s'", nsjconf->iface_vs.c_str());
+	    return false;
+	  }
 	}
-
 	return true;
 }
 #endif  // defined(NSJAIL_NL3_WITH_MACVLAN)

--- a/nsjail.1
+++ b/nsjail.1
@@ -264,6 +264,9 @@ Netmask of the 'vs' interface (e.g. "255.255.255.0")
 .TP
 \fB\-\-macvlan_vs_gw\fR VALUE
 Default GW for the 'vs' interface (e.g. "192.168.0.1")
+.TP
+\fB\-\-macvlan_vs_ma\fR VALUE
+Mac-address of the 'vs' interface (e.g. "ba:ad:ba:be:45:00")
 \"
 .SH Examples
 .PP

--- a/nsjail.h
+++ b/nsjail.h
@@ -125,6 +125,7 @@ struct nsjconf_t {
 	std::string iface_vs_ip;
 	std::string iface_vs_nm;
 	std::string iface_vs_gw;
+	std::string iface_vs_ma;  
 	std::string cgroup_mem_mount;
 	std::string cgroup_mem_parent;
 	size_t cgroup_mem_max;


### PR DESCRIPTION
Hi, 

on some provider (es. OVH) new created interfaces cannot have random macaddress, you must to assign a predefined one so I added _--macvlan_vs_ma_ to nsjail to be able to set it as required.

I think the patch could be useful also for other people than me.

Thanks, Micky