### PR TITLE
Fix utils::writeToFd return type

### DIFF
--- a/subproc.cc
+++ b/subproc.cc
@@ -383,8 +383,7 @@ static bool initParent(nsjconf_t* nsjconf, pid_t pid, int pipefd) {
 		LOG_E("Couldn't initialize user namespace for pid %d", pid);
 		return false;
 	}
-	if (util::writeToFd(pipefd, &kSubprocDoneChar, sizeof(kSubprocDoneChar)) !=
-	    sizeof(kSubprocDoneChar)) {
+	if (!util::writeToFd(pipefd, &kSubprocDoneChar, sizeof(kSubprocDoneChar))) {
 		LOG_E("Couldn't signal the new process via a socketpair");
 		return false;
 	}

--- a/util.cc
+++ b/util.cc
@@ -75,7 +75,7 @@ ssize_t readFromFile(const char* fname, void* buf, size_t len) {
 	return ret;
 }
 
-ssize_t writeToFd(int fd, const void* buf, size_t len) {
+bool writeToFd(int fd, const void* buf, size_t len) {
 	const uint8_t* charbuf = (const uint8_t*)buf;
 
 	size_t writtenSz = 0;


### PR DESCRIPTION
The `writeToFd` function in `util.cc` returns `ssize_t` but the only returned values are either `false` or `true`.
