### PR TITLE
fix writeToFD() return type in declaration

### DIFF
--- a/util.h
+++ b/util.h
@@ -42,7 +42,7 @@ namespace util {
 
 ssize_t readFromFd(int fd, void* buf, size_t len);
 ssize_t readFromFile(const char* fname, void* buf, size_t len);
-ssize_t writeToFd(int fd, const void* buf, size_t len);
+bool writeToFd(int fd, const void* buf, size_t len);
 bool writeBufToFile(const char* filename, const void* buf, size_t len, int open_flags);
 bool createDirRecursively(const char* dir);
 std::string* StrAppend(std::string* str, const char* format, ...)


### PR DESCRIPTION
In 25a7791d return type of writeToFD() was changed from `ssize_t` to `bool`, but header wasn't updated.