### PR TITLE
Fixed missing dependency on libnl-route-3-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get -y update && apt-get install -y \
     g++ \
     git \
     libprotobuf-dev \
+    libnl-route-3-dev \
     libtool \
     make \
     pkg-config \


### PR DESCRIPTION
The example compiling Docker in the readme didn't work, but this fixes it.

It looks like the Makefile treats libnl as optional, but based on the include in net.cc, it appears to be a hard requirement. Let me know if it would be useful to also modify the makefile to fail hard if libnl is mssing instead of warning and continuing.