### PR TITLE
Add flag to disable rlimits

### DIFF
--- a/cmdline.cc
+++ b/cmdline.cc
@@ -108,6 +108,7 @@ struct custom_option custom_opts[] = {
     { { "rlimit_nofile", required_argument, NULL, 0x0205 }, "RLIMIT_NOFILE, 'max' or 'hard' for the current hard limit, 'def' or 'soft' for the current soft limit, 'inf' for RLIM64_INFINITY (default: 32)" },
     { { "rlimit_nproc", required_argument, NULL, 0x0206 }, "RLIMIT_NPROC, 'max' or 'hard' for the current hard limit, 'def' or 'soft' for the current soft limit, 'inf' for RLIM64_INFINITY (default: 'soft')" },
     { { "rlimit_stack", required_argument, NULL, 0x0207 }, "RLIMIT_STACK in MB, 'max' or 'hard' for the current hard limit, 'def' or 'soft' for the current soft limit, 'inf' for RLIM64_INFINITY (default: 'soft')" },
+    { { "disable_rlimits", no_argument, NULL, 0x0208 }, "Disable all rlimits, default to limits set by parent" },
     { { "persona_addr_compat_layout", no_argument, NULL, 0x0301 }, "personality(ADDR_COMPAT_LAYOUT)" },
     { { "persona_mmap_page_zero", no_argument, NULL, 0x0302 }, "personality(MMAP_PAGE_ZERO)" },
     { { "persona_read_implies_exec", no_argument, NULL, 0x0303 }, "personality(READ_IMPLIES_EXEC)" },
@@ -408,6 +409,7 @@ std::unique_ptr<nsjconf_t> parseArgs(int argc, char* argv[]) {
 	nsjconf->rl_nofile = 32ULL;
 	nsjconf->rl_nproc = parseRLimit(RLIMIT_NPROC, "soft", 1);
 	nsjconf->rl_stack = parseRLimit(RLIMIT_STACK, "soft", 1);
+	nsjconf->disable_rl = false;
 	nsjconf->personality = 0;
 	nsjconf->clone_newnet = true;
 	nsjconf->clone_newuser = true;
@@ -548,6 +550,9 @@ std::unique_ptr<nsjconf_t> parseArgs(int argc, char* argv[]) {
 			break;
 		case 0x0207:
 			nsjconf->rl_stack = parseRLimit(RLIMIT_STACK, optarg, (1024 * 1024));
+			break;
+		case 0x0208:
+			nsjconf->disable_rl = true;
 			break;
 		case 0x0301:
 			nsjconf->personality |= ADDR_COMPAT_LAYOUT;

--- a/config.cc
+++ b/config.cc
@@ -160,6 +160,7 @@ static bool configParseInternal(nsjconf_t* nsjconf, const nsjail::NsJailConfig& 
 	nsjconf->rl_nproc = configRLimit(RLIMIT_NPROC, njc.rlimit_nproc_type(), njc.rlimit_nproc());
 	nsjconf->rl_stack = configRLimit(
 	    RLIMIT_STACK, njc.rlimit_stack_type(), njc.rlimit_stack(), 1024UL * 1024UL);
+	nsjconf->disable_rl = njc.disable_rl();
 
 	if (njc.persona_addr_compat_layout()) {
 		nsjconf->personality |= ADDR_COMPAT_LAYOUT;

--- a/config.proto
+++ b/config.proto
@@ -249,4 +249,7 @@ message NsJailConfig {
 
     /* Use cgroup v2 */
     optional bool use_cgroupv2 = 83 [default = false];
+
+    /* Disable all rlimits, default to limits set by parent */
+    optional bool disable_rl = 84 [default = false];
 }

--- a/contain.cc
+++ b/contain.cc
@@ -120,6 +120,10 @@ static bool containCPU(nsjconf_t* nsjconf) {
 }
 
 static bool containSetLimits(nsjconf_t* nsjconf) {
+	if (nsjconf->disable_rl) {
+		return true;
+	}
+
 	struct rlimit64 rl;
 	rl.rlim_cur = rl.rlim_max = nsjconf->rl_as;
 	if (setrlimit64(RLIMIT_AS, &rl) == -1) {

--- a/nsjail.1
+++ b/nsjail.1
@@ -136,6 +136,9 @@ RLIMIT_NPROC, 'max' or 'hard' for the current hard limit, 'def' or 'soft' for th
 \fB\-\-rlimit_stack\fR VALUE
 RLIMIT_STACK in MB, 'max' or 'hard' for the current hard limit, 'def' or 'soft' for the current soft limit, 'inf' for RLIM_INFINITY (default: 'soft')
 .TP
+\fB\-\-disable_rlimits\fR
+Disable all rlimits, default to limits set by parent
+.TP
 \fB\-\-persona_addr_compat_layout\fR
 personality(ADDR_COMPAT_LAYOUT)
 .TP

--- a/nsjail.h
+++ b/nsjail.h
@@ -104,6 +104,7 @@ struct nsjconf_t {
 	uint64_t rl_nofile;
 	uint64_t rl_nproc;
 	uint64_t rl_stack;
+	bool disable_rl;
 	unsigned long personality;
 	bool clone_newnet;
 	bool clone_newuser;


### PR DESCRIPTION
It might be useful to disable the default `rlimits` set by NSJail and instead use `cgroups` to control a processes access to these resources. 

This flag will prevent any rlimit values being set, and instead default the values to whatever the parent has set, as per http://man7.org/linux/man-pages/man2/getrlimit.2.html 