### PR TITLE
Fix default rlimit_stack value

### DIFF
--- a/config.proto
+++ b/config.proto
@@ -157,7 +157,7 @@ message NsJailConfig {
     optional uint64 rlimit_nproc = 38 [default = 1024];
     optional RLimit rlimit_nproc_type = 39 [default = SOFT];
     /* In MiB, use the soft limit value by default */
-    optional uint64 rlimit_stack = 40 [default = 1048576];
+    optional uint64 rlimit_stack = 40 [default = 8];
     optional RLimit rlimit_stack_type = 41 [default = SOFT];
 
     /* Disable all rlimits, default to limits set by parent */


### PR DESCRIPTION
The default `rlimit_stack` value is 1048576. However, this value is in MiB and so is later multiplied by 1024*1024 in https://github.com/google/nsjail/blob/b3d544d155f5d1543dce1bd3e5327ef41583815a/config.cc#L162-L163 and it ends up as a limit of 1 TB for the stack size.

This PR changes it to 8 MB which is a more sane default or, at least I took it from my virtual machine's ulimits:
```
$ ulimit -a
core file size          (blocks, -c) 0
data seg size           (kbytes, -d) unlimited
scheduling priority             (-e) 0
file size               (blocks, -f) unlimited
pending signals                 (-i) 31175
max locked memory       (kbytes, -l) 16384
max memory size         (kbytes, -m) unlimited
open files                      (-n) 1024
pipe size            (512 bytes, -p) 8
POSIX message queues     (bytes, -q) 819200
real-time priority              (-r) 0
stack size              (kbytes, -s) 8192
cpu time               (seconds, -t) unlimited
max user processes              (-u) 31175
virtual memory          (kbytes, -v) unlimited
file locks                      (-x) unlimited
```