### PR TITLE
fix non-functional max_conns_per_ip

### DIFF
--- a/subproc.cc
+++ b/subproc.cc
@@ -409,7 +409,7 @@ static bool initParent(nsjconf_t* nsjconf, pid_t pid, int pipefd) {
 }
 
 bool runChild(nsjconf_t* nsjconf, int netfd, int fd_in, int fd_out, int fd_err) {
-	if (!net::limitConns(nsjconf, fd_in)) {
+	if (!net::limitConns(nsjconf, netfd)) {
 		return true;
 	}
 	unsigned long flags = 0UL;


### PR DESCRIPTION
Starting with nsjail::listenMode update to pipe socket traffic [commit 273ce6bc846b7325c7f0915067c54bf8cf6f5654], a pipe file descriptor is passed as connsock parameter when calling net::limitConns and also as sock parameter when calling addProc in subproc::runChild.
This breaks net::limitConns because pid.remote_addr and also local variable addr are left uninitialized despite net::connToText calls when counting number of existing network connections from the same peer.

The subsequent correction to fetch remote address [commit 2cf562160d308f9b5cca767a2459332f2041b41c] made the bug even more interesting, since the loop in net::limitConns now compares unsanitized content of stack with network addresses of already connected clients.