### PR TITLE
Build-time config of newuidmap and newgidmap paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ COMMON_FLAGS += -O2 -c \
 	-Wall -Wextra -Werror \
 	-Ikafel/include
 
-CXXFLAGS += $(COMMON_FLAGS) $(shell pkg-config --cflags protobuf) \
+CXXFLAGS += $(USER_DEFINES) $(COMMON_FLAGS) $(shell pkg-config --cflags protobuf) \
 	-std=c++11 -fno-exceptions -Wno-unused -Wno-unused-parameter
 LDFLAGS += -pie -Wl,-z,noexecstack -lpthread $(shell pkg-config --libs protobuf)
 

--- a/user.cc
+++ b/user.cc
@@ -43,6 +43,14 @@
 #include "subproc.h"
 #include "util.h"
 
+#ifndef NEWUIDMAP_PATH
+#define NEWUIDMAP_PATH "/usr/bin/newuidmap"
+#endif
+
+#ifndef NEWGIDMAP_PATH
+#define NEWGIDMAP_PATH "/usr/bin/newgidmap"
+#endif
+
 namespace user {
 
 static bool setResGid(gid_t gid) {
@@ -161,11 +169,11 @@ static bool gidMapSelf(nsjconf_t* nsjconf, pid_t pid) {
 	return true;
 }
 
-/* Use /usr/bin/newgidmap for writing the gid map */
+/* Use NEWGIDMAP_PATH for writing the gid map */
 static bool gidMapExternal(nsjconf_t* nsjconf, pid_t pid) {
 	bool use = false;
 
-	std::vector<std::string> argv = {"/usr/bin/newgidmap", std::to_string(pid)};
+	std::vector<std::string> argv = {NEWGIDMAP_PATH, std::to_string(pid)};
 	for (const auto& gid : nsjconf->gids) {
 		if (!gid.is_newidmap) {
 			continue;
@@ -180,18 +188,18 @@ static bool gidMapExternal(nsjconf_t* nsjconf, pid_t pid) {
 		return true;
 	}
 	if (subproc::systemExe(argv, environ) != 0) {
-		LOG_E("'/usr/bin/newgidmap' failed");
+		LOG_E("'%s' failed", NEWGIDMAP_PATH);
 		return false;
 	}
 
 	return true;
 }
 
-/* Use /usr/bin/newuidmap for writing the uid map */
+/* Use NEWUIDMAP_PATH for writing the uid map */
 static bool uidMapExternal(nsjconf_t* nsjconf, pid_t pid) {
 	bool use = false;
 
-	std::vector<std::string> argv = {"/usr/bin/newuidmap", std::to_string(pid)};
+	std::vector<std::string> argv = {NEWUIDMAP_PATH, std::to_string(pid)};
 	for (const auto& uid : nsjconf->uids) {
 		if (!uid.is_newidmap) {
 			continue;
@@ -206,7 +214,7 @@ static bool uidMapExternal(nsjconf_t* nsjconf, pid_t pid) {
 		return true;
 	}
 	if (subproc::systemExe(argv, environ) != 0) {
-		LOG_E("'/usr/bin/newuidmap' failed");
+		LOG_E("'%s' failed", NEWUIDMAP_PATH);
 		return false;
 	}
 

--- a/user.cc
+++ b/user.cc
@@ -43,12 +43,20 @@
 #include "subproc.h"
 #include "util.h"
 
-#ifndef NEWUIDMAP_PATH
-#define NEWUIDMAP_PATH "/usr/bin/newuidmap"
-#endif
+#define STR_(x) #x
+#define STR(x) STR_(x)
 
-#ifndef NEWGIDMAP_PATH
-#define NEWGIDMAP_PATH "/usr/bin/newgidmap"
+constexpr char kNewUidPath[] =
+#ifdef NEWUIDMAP_PATH
+  STR(NEWUIDMAP_PATH);
+#else
+  "/usr/bin/newuidmap";
+#endif
+constexpr char kNewGidPath[] =
+#ifdef NEWGIDMAP_PATH
+  STR(NEWGIDMAP_PATH);
+#else
+  "/usr/bin/newgidmap";
 #endif
 
 namespace user {
@@ -169,11 +177,11 @@ static bool gidMapSelf(nsjconf_t* nsjconf, pid_t pid) {
 	return true;
 }
 
-/* Use NEWGIDMAP_PATH for writing the gid map */
+/* Use newgidmap for writing the gid map */
 static bool gidMapExternal(nsjconf_t* nsjconf, pid_t pid) {
 	bool use = false;
 
-	std::vector<std::string> argv = {NEWGIDMAP_PATH, std::to_string(pid)};
+	std::vector<std::string> argv = {kNewGidPath, std::to_string(pid)};
 	for (const auto& gid : nsjconf->gids) {
 		if (!gid.is_newidmap) {
 			continue;
@@ -188,18 +196,18 @@ static bool gidMapExternal(nsjconf_t* nsjconf, pid_t pid) {
 		return true;
 	}
 	if (subproc::systemExe(argv, environ) != 0) {
-		LOG_E("'%s' failed", NEWGIDMAP_PATH);
+		LOG_E("'%s' failed", kNewGidPath);
 		return false;
 	}
 
 	return true;
 }
 
-/* Use NEWUIDMAP_PATH for writing the uid map */
+/* Use newuidmap for writing the uid map */
 static bool uidMapExternal(nsjconf_t* nsjconf, pid_t pid) {
 	bool use = false;
 
-	std::vector<std::string> argv = {NEWUIDMAP_PATH, std::to_string(pid)};
+	std::vector<std::string> argv = {kNewUidPath, std::to_string(pid)};
 	for (const auto& uid : nsjconf->uids) {
 		if (!uid.is_newidmap) {
 			continue;
@@ -214,7 +222,7 @@ static bool uidMapExternal(nsjconf_t* nsjconf, pid_t pid) {
 		return true;
 	}
 	if (subproc::systemExe(argv, environ) != 0) {
-		LOG_E("'%s' failed", NEWUIDMAP_PATH);
+		LOG_E("'%s' failed", kNewUidPath);
 		return false;
 	}
 


### PR DESCRIPTION
Currently `newuidmap` and `newgidmap` paths are hardcoded to `/usr/bin/...`. Some Linux distributions do not follow the conventional FHS and need to patch the source code before building:

https://github.com/NixOS/nixpkgs/blob/f72a67f7d8a1bcca82d3961c73c7f44f264e3548/pkgs/tools/security/nsjail/default.nix#L18-L20

This PR allows to configure `newuidmap` and `newgidmap` paths through a make flag:
```sh
make USER_DEFINES='-DNEWUIDMAP_PATH=\"/path/to/newuidmap\" -DNEWGIDMAP_PATH=\"/path/to/newgidmap\"'
```