### PR TITLE
Fixes #146: cgroups_mem_max unit in config.proto

### DIFF
--- a/config.proto
+++ b/config.proto
@@ -196,7 +196,7 @@ message NsJailConfig {
     optional bool seccomp_log = 60 [default = false];
 
     /* If > 0, maximum cumulative size of RAM used inside any jail */
-    optional uint64 cgroup_mem_max = 61 [default = 0]; /* In MiB */
+    optional uint64 cgroup_mem_max = 61 [default = 0]; /* In bytes */
     /* Mount point for cgroups-memory in your system */
     optional string cgroup_mem_mount = 62 [default = "/sys/fs/cgroup/memory"];
     /* Writeable directory (for the nsjail user) under cgroup_mem_mount */


### PR DESCRIPTION
This commit fixes the incorrect cgroups_mem_max unit described in a config.proto comment.

We do not perform any calculations on this value and we don't specify the values unit (k/M/G) when writing to memory cgroup controller files, so the value is specified in bytes.