### PR TITLE
Fix compilation errors on old gcc (5.4.0)

### DIFF
--- a/nsjail.cc
+++ b/nsjail.cc
@@ -166,7 +166,9 @@ static bool pipeTraffic(nsjconf_t* nsjconf, int listenfd) {
 			const char* direction;
 			bool closed = false;
 			std::tuple<int, int, const char*> direction_map[] = {
-			    {i, i + 1, "in"}, {i + 2, i, "out"}};
+				std::make_tuple(i, i + 1, "in"),
+				std::make_tuple(i + 2, i, "out"),
+			};
 			for (const auto& entry : direction_map) {
 				std::tie(in, out, direction) = entry;
 				bool in_ready = (fds[in].events & POLLIN) == 0 ||


### PR DESCRIPTION
Just use explicit `std::make_tuple` constructors.

Not sure if you care about building nsjail on older compilers, but this commit enables it e.g. on gcc 5.4.0, which is default on ubuntu 16.04