### PR TITLE
remove build dependency on which

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-PKG_CONFIG=$(shell which pkg-config)
+PKG_CONFIG=$(shell command -v pkg-config 2> /dev/null)
 ifeq ($(PKG_CONFIG),)
 $(error "Install pkg-config to make it work")
 endif


### PR DESCRIPTION
We're building nsjail for a few different targets (fedora, centos) that don't include `which` in their standard/base docker images. This small change removes the need for installing another build time dependency by relying on the shell's `command` func instead.

I'm not sure if `command` is a bashism and may not be portable but I think with nsjail's ties to Linux specific features that this is safe for most Linux distros.