### PR TITLE
Exec wrapper

### DIFF
--- a/cmdline.cc
+++ b/cmdline.cc
@@ -329,14 +329,14 @@ static bool setupArgv(nsjconf_t* nsjconf, int argc, char** argv, int optind) {
 		    "specified the --execute_fd flag");
 		return false;
 #endif /* !defined(__NR_execveat) */
-        int open_flags = O_RDONLY | O_PATH;
+	int open_flags = O_RDONLY | O_PATH;
 
-        // we need to pass the file decriptor to exec_wrapper
-        if(nsjconf->exec_wrapper.length() == 0)
-            open_flags |= O_CLOEXEC;
+	// we need to pass the file decriptor to exec_wrapper
+	if(nsjconf->exec_wrapper.length() == 0)
+		open_flags |= O_CLOEXEC;
 
 		if ((nsjconf->exec_fd = TEMP_FAILURE_RETRY(
-			 open(nsjconf->exec_file.c_str(), open_flags))) == -1) {
+			open(nsjconf->exec_file.c_str(), open_flags))) == -1) {
 			PLOG_W("Couldn't open '%s' file", nsjconf->exec_file.c_str());
 			return false;
 		}
@@ -402,7 +402,7 @@ std::unique_ptr<nsjconf_t> parseArgs(int argc, char* argv[]) {
 	nsjconf->hostname = "NSJAIL";
 	nsjconf->cwd = "/";
 	nsjconf->port = 0;
-    nsjconf->exec_wrapper = "";
+	nsjconf->exec_wrapper = "";
 	nsjconf->bindhost = "::";
 	nsjconf->daemonize = false;
 	nsjconf->tlimit = 0;

--- a/cmdline.cc
+++ b/cmdline.cc
@@ -331,7 +331,7 @@ static bool setupArgv(nsjconf_t* nsjconf, int argc, char** argv, int optind) {
 #endif /* !defined(__NR_execveat) */
         int open_flags = O_RDONLY | O_PATH;
 
-        // we need to pase the file decriptor to exec_wrapper
+        // we need to pass the file decriptor to exec_wrapper
         if(nsjconf->exec_wrapper.length() == 0)
             open_flags |= O_CLOEXEC;
 

--- a/cmdline.cc
+++ b/cmdline.cc
@@ -156,7 +156,7 @@ struct custom_option custom_opts[] = {
     { { "macvlan_vs_nm", required_argument, NULL, 0x702 }, "Netmask of the 'vs' interface (e.g. \"255.255.255.0\")" },
     { { "macvlan_vs_gw", required_argument, NULL, 0x703 }, "Default GW for the 'vs' interface (e.g. \"192.168.0.1\")" },
     { { "macvlan_vs_ma", required_argument, NULL, 0x705 }, "MAC-address of the 'vs' interface (e.g. \"ba:ad:ba:be:45:00\")" },
-    { { "exec_wrapper", required_argument, NULL, 0x706 }, "TODO" },
+    { { "exec_wrapper", required_argument, NULL, 0x706 }, "Path to wrapper binary that will get the main binary and its args as arguments. This can be used to implement e.g. a PoW challenge. The wrapper will be invoked as `exec_wrapper --file <binary-path> -- <args>` or as `exec_wrapper --fd <binary-fd> -- <args> if `--execute_fd` is passed."},
 };
 // clang-format on
 

--- a/cmdline.cc
+++ b/cmdline.cc
@@ -329,11 +329,12 @@ static bool setupArgv(nsjconf_t* nsjconf, int argc, char** argv, int optind) {
 		    "specified the --execute_fd flag");
 		return false;
 #endif /* !defined(__NR_execveat) */
-	int open_flags = O_RDONLY | O_PATH;
+		int open_flags = O_RDONLY | O_PATH;
 
-	// we need to pass the file decriptor to exec_wrapper
-	if(nsjconf->exec_wrapper.length() == 0)
-		open_flags |= O_CLOEXEC;
+		// we need to pass the file decriptor to exec_wrapper
+		if(nsjconf->exec_wrapper.length() == 0) {
+			open_flags |= O_CLOEXEC;
+		}
 
 		if ((nsjconf->exec_fd = TEMP_FAILURE_RETRY(
 			open(nsjconf->exec_file.c_str(), open_flags))) == -1) {

--- a/nsjail.h
+++ b/nsjail.h
@@ -100,7 +100,7 @@ struct nsjconf_t {
 	std::string hostname;
 	std::string cwd;
 	std::string chroot;
-    std::string exec_wrapper;
+	std::string exec_wrapper;
 	int port;
 	std::string bindhost;
 	bool daemonize;

--- a/nsjail.h
+++ b/nsjail.h
@@ -100,6 +100,7 @@ struct nsjconf_t {
 	std::string hostname;
 	std::string cwd;
 	std::string chroot;
+    std::string exec_wrapper;
 	int port;
 	std::string bindhost;
 	bool daemonize;

--- a/subproc.cc
+++ b/subproc.cc
@@ -201,15 +201,15 @@ static void subprocNewProc(
 	/* Should be the last one in the sequence */
 	if (!sandbox::applyPolicy(nsjconf)) {
 		return;
-    }
+	}
     
-    if(exec_wrapper_fd > 0) {
-        LOG_I("executing wrapper");
+	if(exec_wrapper_fd > 0) {
+		LOG_I("executing wrapper");
 		util::syscall(__NR_execveat, exec_wrapper_fd, (uintptr_t) "",
-		    (uintptr_t)argv.data(), (uintptr_t)environ, AT_EMPTY_PATH);
-    	PLOG_E("execve('%s') failed", nsjconf->exec_wrapper.c_str());
-        return;
-    }
+		              (uintptr_t)argv.data(), (uintptr_t)environ, AT_EMPTY_PATH);
+		PLOG_E("execve('%s') failed", nsjconf->exec_wrapper.c_str());
+		return;
+	}
 
 	if (nsjconf->use_execveat) {
 #if defined(__NR_execveat)
@@ -442,14 +442,14 @@ pid_t runChild(nsjconf_t* nsjconf, int netfd, int fd_in, int fd_out, int fd_err)
 	flags |= (nsjconf->clone_newuts ? CLONE_NEWUTS : 0);
 	flags |= (nsjconf->clone_newcgroup ? CLONE_NEWCGROUP : 0);
 
-    int exec_wrapper_fd = -1;
-    if(nsjconf->exec_wrapper.length() > 0) {
-       exec_wrapper_fd = open(nsjconf->exec_wrapper.c_str(), O_RDONLY | O_PATH | O_CLOEXEC);
-       if (exec_wrapper_fd < 0) {
-            LOG_E("Error, failed to open exec_wrapper: %s", nsjconf->exec_wrapper.c_str());
-            return false;
-       }
-    }
+	int exec_wrapper_fd = -1;
+	if(nsjconf->exec_wrapper.length() > 0) {
+		exec_wrapper_fd = open(nsjconf->exec_wrapper.c_str(), O_RDONLY | O_PATH | O_CLOEXEC);
+		if (exec_wrapper_fd < 0) {
+			LOG_E("Error, failed to open exec_wrapper: %s", nsjconf->exec_wrapper.c_str());
+			return false;
+		}
+	}
 
 	if (nsjconf->mode == MODE_STANDALONE_EXECVE) {
 		if (unshare(flags) == -1) {

--- a/subproc.cc
+++ b/subproc.cc
@@ -179,18 +179,18 @@ static void subprocNewProc(
 	LOG_I("Executing '%s' for '%s'", nsjconf->exec_file.c_str(), connstr.c_str());
 
 	std::vector<const char*> argv;
-    std::string fd_string = std::to_string(exec_wrapper_fd);
-    if (exec_wrapper_fd > 0) {
-        argv.push_back("exec_wrapper");
-        if(nsjconf->use_execveat) {
-            argv.push_back("--fd");
-            argv.push_back(fd_string.c_str());
-        } else {
-            argv.push_back("--file");
-            argv.push_back(nsjconf->exec_file.c_str());
-        }
-        argv.push_back("--");
-    }
+	std::string fd_string = std::to_string(exec_wrapper_fd);
+	if (exec_wrapper_fd > 0) {
+		argv.push_back("exec_wrapper");
+		if(nsjconf->use_execveat) {
+			argv.push_back("--fd");
+			argv.push_back(fd_string.c_str());
+		} else {
+			argv.push_back("--file");
+			argv.push_back(nsjconf->exec_file.c_str());
+		}
+		argv.push_back("--");
+	}
 
 	for (const auto& s : nsjconf->argv) {
 		argv.push_back(s.c_str());


### PR DESCRIPTION
This PR implements the `exec_wrapper` as described in https://github.com/google/nsjail/issues/143#issuecomment-661930046.

This can be used to wrap the jailed binary e.g. to require solving a PoW challenge or authenticate before the main binary is launched. The specified `exec_wrapper` needs to launch the child binary by itself.

An example exec wrapper implementation/code can be seen below.

```c
#define _GNU_SOURCE
#include <sys/syscall.h>
#include <fcntl.h>
#include <stdio.h>
#include <string.h>
#include <stdlib.h>
#include <unistd.h>


int main(int argc, char* argv[], char* envp[]) {
	if (argc < 4)
		goto fail;

	for(int i=0; i<argc; ++i)
		printf("argv[%d] = '%s'\n", i, argv[i]);

	// Invoked as: exec_wrapper --file <binary-path> -- <argv0> <argv1> ...
	if (!strcmp(argv[1], "--file")) {
		printf("execve(%s)\n", argv[2]);
		return execve(argv[2], &argv[4], envp);
	}
	// Invoked as: exec_wrapper --fd <binary-fd> -- <argv0> <argv1> ...
	else if (!strcmp(argv[1], "--fd")) {
		int fd = atoi(argv[2]);
		//return execveat(fd, "", &argv[4], envp, AT_EMPTY_PATH); // some libcs are missing it...
		return syscall(SYS_execveat, fd, "", &argv[4], envp, AT_EMPTY_PATH);
	}

	fail:
	fprintf(stderr, "exec_wrapper usage: exec_wrapper (--file|--fd) <binary-path-or-fd> -- <argv0> <argv1> ...");
	return -1;
}
```

And the way we use it (in standard nsjail container - after `docker build -t nsjail . && docker run --privileged --rm -it --net none nsjail .`):
```
root@e7c8d0c7d074:/# gcc main.c
root@e7c8d0c7d074:/# nsjail -Mo --chroot / --exec_wrapper /a.out /bin/echo "ABC"
[I][2020-09-07T16:41:52+0000] Mode: STANDALONE_ONCE
[I][2020-09-07T16:41:52+0000] Jail parameters: hostname:'NSJAIL', chroot:'/', process:'/bin/echo', bind:[::]:0, max_conns_per_ip:0, time_limit:0, personality:0, daemonize:false, clone_newnet:true, clone_newuser:true, clone_newns:true, clone_newpid:true, clone_newipc:true, clone_newuts:true, clone_newcgroup:true, keep_caps:false, disable_no_new_privs:false, max_cpus:0
[I][2020-09-07T16:41:52+0000] Mount: '/' -> '/' flags:MS_RDONLY|MS_BIND|MS_REC|MS_PRIVATE type:'' options:'' dir:true
[I][2020-09-07T16:41:52+0000] Mount: '/proc' flags:MS_RDONLY type:'proc' options:'' dir:true
[I][2020-09-07T16:41:52+0000] Uid map: inside_uid:0 outside_uid:0 count:1 newuidmap:false
[W][2020-09-07T16:41:52+0000][687] void cmdline::logParams(nsjconf_t*)():255 Process will be UID/EUID=0 in the global user namespace, and will have user root-level access to files
[I][2020-09-07T16:41:52+0000] Gid map: inside_gid:0 outside_gid:0 count:1 newgidmap:false
[W][2020-09-07T16:41:52+0000][687] void cmdline::logParams(nsjconf_t*)():265 Process will be GID/EGID=0 in the global user namespace, and will have group root-level access to files
[I][2020-09-07T16:41:52+0000] Executing '/bin/echo' for '[STANDALONE MODE]'
[I][2020-09-07T16:41:52+0000] executing wrapper
argv[0] = 'exec_wrapper'
argv[1] = '--file'
argv[2] = '/bin/echo'
argv[3] = '--'
argv[4] = '/bin/echo'
argv[5] = 'ABC'
execve(/bin/echo)
ABC
[I][2020-09-07T16:41:52+0000] pid=688 ([STANDALONE MODE]) exited with status: 0, (PIDs left: 0)
root@e7c8d0c7d074:/#
```