### PR TITLE
net: add support for max_conns

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,8 @@ Options:
 	TCP port to bind to (enables MODE_LISTEN_TCP) (default: 0)
  --bindhost VALUE
 	IP address to bind the port to (only in [MODE_LISTEN_TCP]), (default: '::')
+ --max_conns VALUE
+	Maximum number of connections across all IPs (only in [MODE_LISTEN_TCP]), (default: 0 (unlimited))
  --max_conns_per_ip|-i VALUE
 	Maximum number of connections per one IP (only in [MODE_LISTEN_TCP]), (default: 0 (unlimited))
  --log|-l VALUE

--- a/config.cc
+++ b/config.cc
@@ -86,6 +86,7 @@ static bool configParseInternal(nsjconf_t* nsjconf, const nsjail::NsJailConfig& 
 	nsjconf->cwd = njc.cwd();
 	nsjconf->port = njc.port();
 	nsjconf->bindhost = njc.bindhost();
+	nsjconf->max_conns = njc.max_conns();
 	nsjconf->max_conns_per_ip = njc.max_conns_per_ip();
 	nsjconf->tlimit = njc.time_limit();
 	nsjconf->max_cpus = njc.max_cpus();

--- a/config.proto
+++ b/config.proto
@@ -90,6 +90,8 @@ message NsJailConfig {
     optional uint32 port = 10 [default = 0];
     /* Host to bind to for mode=LISTEN. Must be in IPv6 format */
     optional string bindhost = 11 [default = "::"];
+    /* For mode=LISTEN, maximum number of connections across all IPs */
+    optional uint32 max_conns = 85 [default = 0];
     /* For mode=LISTEN, maximum number of connections from a single IP */
     optional uint32 max_conns_per_ip = 12 [default = 0];
 

--- a/net.cc
+++ b/net.cc
@@ -182,6 +182,12 @@ static bool isSocket(int fd) {
 
 bool limitConns(nsjconf_t* nsjconf, int connsock) {
 	/* 0 means 'unlimited' */
+	if (nsjconf->max_conns != 0 && nsjconf->pids.size() >= nsjconf->max_conns) {
+		LOG_W("Rejecting connection, max_conns limit reached: %u", nsjconf->max_conns);
+		return false;
+	}
+
+	/* 0 means 'unlimited' */
 	if (nsjconf->max_conns_per_ip == 0) {
 		return true;
 	}

--- a/nsjail.1
+++ b/nsjail.1
@@ -61,6 +61,9 @@ TCP port to bind to (enables MODE_LISTEN_TCP) (default: 0)
 \fB\-\-bindhost\fR VALUE
 IP address to bind the port to (only in [MODE_LISTEN_TCP]), (default: '::')
 .TP
+\fB\-\-max_conns\fR VALUE
+Maximum number of connections across all IPs (only in [MODE_LISTEN_TCP]), (default: 0 (unlimited))
+.TP
 \fB\-\-max_conns_per_ip\fR|\fB\-i\fR VALUE
 Maximum number of connections per one IP (only in [MODE_LISTEN_TCP]), (default: 0 (unlimited))
 .TP

--- a/nsjail.h
+++ b/nsjail.h
@@ -129,6 +129,7 @@ struct nsjconf_t {
 	bool is_silent;
 	bool stderr_to_null;
 	bool skip_setsid;
+	unsigned int max_conns;
 	unsigned int max_conns_per_ip;
 	std::string proc_path;
 	bool is_proc_rw;


### PR DESCRIPTION
This PR adds the `max_conns` option for both the proto2 config file and the cmdline.

`max_conns` limits the total number of concurrent open connections while in `LISTEN` mode.
