### PR TITLE
write CPU CFS period before quota in cgroup1

### DIFF
--- a/cgroup.cc
+++ b/cgroup.cc
@@ -134,12 +134,12 @@ static bool initNsFromParentCpu(nsjconf_t* nsjconf, pid_t pid) {
 				      "/NSJAIL." + std::to_string(pid);
 	RETURN_ON_FAILURE(createCgroup(cpu_cgroup_path, pid));
 
+	RETURN_ON_FAILURE(
+	    writeToCgroup(cpu_cgroup_path + "/cpu.cfs_period_us", "1000000", "cpu period"));
+
 	std::string cpu_ms_per_sec_str = std::to_string(nsjconf->cgroup_cpu_ms_per_sec * 1000U);
 	RETURN_ON_FAILURE(
 	    writeToCgroup(cpu_cgroup_path + "/cpu.cfs_quota_us", cpu_ms_per_sec_str, "cpu quota"));
-
-	RETURN_ON_FAILURE(
-	    writeToCgroup(cpu_cgroup_path + "/cpu.cfs_period_us", "1000000", "cpu period"));
 
 	return addPidToTaskList(cpu_cgroup_path, pid);
 }


### PR DESCRIPTION
The CFS CPU limit applied by nsjail must be less than or equal to the limit applied by `cgroup_cpu_parent` and its ancestors.

If the `cpu.cfs_period_us` of any ancestor cgroups is less than `1000000` (nsjail's value), the CPU quota for the new nsjail cgroup can be temporarily greater than its ancestors, even if the `cgroup_cpu_ms` is less than all ancestors. This results in an `EINVAL` when writing `cpu.cfs_quota_us`.

We can avoid this issue by writing `cpu.cfs_period_us` before `cpu.cfs_quota_us`.
