### PR TITLE
Fix mem clean in finishFromParent

### DIFF
--- a/cgroup.cc
+++ b/cgroup.cc
@@ -79,17 +79,17 @@ static bool initNsFromParentMem(nsjconf_t* nsjconf, pid_t pid) {
 	RETURN_ON_FAILURE(writeToCgroup(
 	    mem_cgroup_path + "/memory.oom_control", "0", "memory cgroup oom control"));
 
-        if (nsjconf->cgroup_mem_max > (size_t)0) {
-          std::string mem_max_str = std::to_string(nsjconf->cgroup_mem_max);
-          RETURN_ON_FAILURE(writeToCgroup(
-              mem_cgroup_path + "/memory.limit_in_bytes", mem_max_str, "memory cgroup max limit"));
-        }
+	if (nsjconf->cgroup_mem_max > (size_t)0) {
+		std::string mem_max_str = std::to_string(nsjconf->cgroup_mem_max);
+		RETURN_ON_FAILURE(writeToCgroup(mem_cgroup_path + "/memory.limit_in_bytes",
+		    mem_max_str, "memory cgroup max limit"));
+	}
 
-        if (nsjconf->cgroup_mem_memsw_max > (size_t)0) {
-          std::string mem_memsw_max_str = std::to_string(nsjconf->cgroup_mem_memsw_max);
-          RETURN_ON_FAILURE(writeToCgroup(
-              mem_cgroup_path + "/memory.memsw.limit_in_bytes", mem_memsw_max_str, "memory+Swap cgroup max limit"));
-        }
+	if (nsjconf->cgroup_mem_memsw_max > (size_t)0) {
+		std::string mem_memsw_max_str = std::to_string(nsjconf->cgroup_mem_memsw_max);
+		RETURN_ON_FAILURE(writeToCgroup(mem_cgroup_path + "/memory.memsw.limit_in_bytes",
+		    mem_memsw_max_str, "memory+Swap cgroup max limit"));
+	}
 
 	return addPidToTaskList(mem_cgroup_path, pid);
 }
@@ -167,7 +167,7 @@ static void removeCgroup(const std::string& cgroup_path) {
 }
 
 void finishFromParent(nsjconf_t* nsjconf, pid_t pid) {
-	if (nsjconf->cgroup_mem_max != (size_t)0) {
+	if (nsjconf->cgroup_mem_max != (size_t)0 || nsjconf->cgroup_mem_memsw_max != (size_t)0) {
 		std::string mem_cgroup_path = nsjconf->cgroup_mem_mount + '/' +
 					      nsjconf->cgroup_mem_parent + "/NSJAIL." +
 					      std::to_string(pid);


### PR DESCRIPTION
in #184 , line 68 is modified:

<https://github.com/google/nsjail/blob/29a556068a7491c0c4cf59783a298e317d1f3e09/cgroup.cc#L67-L70>

but line 170 is not modified synchronously

<https://github.com/google/nsjail/blob/29a556068a7491c0c4cf59783a298e317d1f3e09/cgroup.cc#L169-L175>

Although `memory.memsw.limit_in_bytes` cannot be set when `memory.limit_in_bytes` is not set(which means that the memory subsystem will not miss clean in normal conditions), but I think this is a bug.


so I tried to fix it.

Also format spaces as tabs.