### PR TITLE
support cgroup_mem_memsw_max in cgroup2

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,8 @@ Options:
 	Maximum number of bytes to use in the group (default: '0' - disabled)
  --cgroup_mem_memsw_max VALUE
 	Maximum number of memory+Swap bytes to use in the group (default: '0' - disabled)
+ --cgroup_mem_swap_max VALUE
+	Maximum number of swap bytes to use in the group (default: '-1' - disabled)
  --cgroup_mem_mount VALUE
 	Location of memory cgroup FS (default: '/sys/fs/cgroup/memory')
  --cgroup_mem_parent VALUE

--- a/cgroup.cc
+++ b/cgroup.cc
@@ -65,7 +65,12 @@ static bool addPidToTaskList(const std::string& cgroup_path, pid_t pid) {
 }
 
 static bool initNsFromParentMem(nsjconf_t* nsjconf, pid_t pid) {
-	if (nsjconf->cgroup_mem_max == (size_t)0 && nsjconf->cgroup_mem_memsw_max == (size_t)0) {
+	size_t memsw_max = nsjconf->cgroup_mem_memsw_max;
+	if (nsjconf->cgroup_mem_swap_max >= (ssize_t)0) {
+		memsw_max = nsjconf->cgroup_mem_swap_max + nsjconf->cgroup_mem_max;
+	}
+
+	if (nsjconf->cgroup_mem_max == (size_t)0 && memsw_max == (size_t)0) {
 		return true;
 	}
 
@@ -85,8 +90,8 @@ static bool initNsFromParentMem(nsjconf_t* nsjconf, pid_t pid) {
 		    mem_max_str, "memory cgroup max limit"));
 	}
 
-	if (nsjconf->cgroup_mem_memsw_max > (size_t)0) {
-		std::string mem_memsw_max_str = std::to_string(nsjconf->cgroup_mem_memsw_max);
+	if (memsw_max > (size_t)0) {
+		std::string mem_memsw_max_str = std::to_string(memsw_max);
 		RETURN_ON_FAILURE(writeToCgroup(mem_cgroup_path + "/memory.memsw.limit_in_bytes",
 		    mem_memsw_max_str, "memory+Swap cgroup max limit"));
 	}

--- a/config.cc
+++ b/config.cc
@@ -252,6 +252,7 @@ static bool configParseInternal(nsjconf_t* nsjconf, const nsjail::NsJailConfig& 
 
 	nsjconf->cgroup_mem_max = njc.cgroup_mem_max();
 	nsjconf->cgroup_mem_memsw_max = njc.cgroup_mem_memsw_max();
+	nsjconf->cgroup_mem_swap_max = njc.cgroup_mem_swap_max();
 	nsjconf->cgroup_mem_mount = njc.cgroup_mem_mount();
 	nsjconf->cgroup_mem_parent = njc.cgroup_mem_parent();
 	nsjconf->cgroup_pids_max = njc.cgroup_pids_max();

--- a/config.proto
+++ b/config.proto
@@ -213,6 +213,8 @@ message NsJailConfig {
     optional uint64 cgroup_mem_max = 67 [default = 0]; /* In bytes */
     /* If > 0, maximum cumulative size of RAM + swap used inside any jail */
     optional uint64 cgroup_mem_memsw_max = 91 [default = 0]; /* In bytes */
+    /* If >= 0, maximum cumulative size of swap used inside any jail */
+    optional int64 cgroup_mem_swap_max = 92 [default = -1]; /* In bytes */
     /* Mount point for cgroups-memory in your system */
     optional string cgroup_mem_mount = 68 [default = "/sys/fs/cgroup/memory"];
     /* Writeable directory (for the nsjail user) under cgroup_mem_mount */

--- a/nsjail.1
+++ b/nsjail.1
@@ -223,6 +223,9 @@ Maximum number of bytes to use in the group (default: '0' \- disabled)
 \fB\-\-cgroup_mem_memsw_max\fR VALUE
 Maximum number of memory+Swap bytes to use in the group (default: '0' \- disabled)
 .TP
+\fB\-\-cgroup_mem_swap_max\fR VALUE
+Maximum number of swap bytes to use in the group (default: '-1' \- disabled)
+.TP
 \fB\-\-cgroup_mem_mount\fR VALUE
 Location of memory cgroup FS (default: '/sys/fs/cgroup/memory')
 .TP

--- a/nsjail.h
+++ b/nsjail.h
@@ -149,6 +149,7 @@ struct nsjconf_t {
 	std::string cgroup_mem_parent;
 	size_t cgroup_mem_max;
 	size_t cgroup_mem_memsw_max;
+	ssize_t cgroup_mem_swap_max;
 	std::string cgroup_pids_mount;
 	std::string cgroup_pids_parent;
 	unsigned int cgroup_pids_max;


### PR DESCRIPTION
Currently, `cgroup_mem_memsw_max` is only used with cgroup v1. The option is silently ignored with cgroup v2.

Because there is no way to limit swap + memory usage in cgroup v2, we write `cgroup_mem_memsw_max - cgroup_mem_max` to `memory.swap.max`.
