### PR TITLE
Fix compile using `FROM ubuntu:20.04`

### DIFF
--- a/subproc.cc
+++ b/subproc.cc
@@ -526,19 +526,9 @@ pid_t cloneProc(uintptr_t flags, int exit_signal) {
 	}
 
 #if defined(__NR_clone3)
-	struct clone_args ca = {
-	    .flags = (uint64_t)flags,
-	    .pidfd = 0,
-	    .child_tid = 0,
-	    .parent_tid = 0,
-	    .exit_signal = (uint64_t)exit_signal,
-	    .stack = 0,
-	    .stack_size = 0,
-	    .tls = 0,
-	    .set_tid = 0,
-	    .set_tid_size = 0,
-	    .cgroup = 0,
-	};
+    struct clone_args ca = {};
+    ca.flags = (uint64_t)flags;
+    ca.exit_signal = (uint64_t)exit_signal;
 
 	pid_t ret = util::syscall(__NR_clone3, (uintptr_t)&ca, sizeof(ca));
 	if (ret != -1 || errno != ENOSYS) {


### PR DESCRIPTION
`struct clone_args` (for clone3) only has `set_tid` and `set_tid_size` in Linux 5.5 and `cgroup` in Linux 5.7. This breaks builds based on the ubuntu:20.04 docker image (which ships with 5.4 headers)

Example Dockerfile snippet:
```
FROM ubuntu:20.04
 
 # Install nsjail
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -y update && apt-get install -y \
 autoconf \
 bison \
 flex \
 gcc \
 g++ \
 git \
 libprotobuf-dev \
 libnl-route-3-dev \
 libtool \
 make \
 pkg-config \
 protobuf-compiler \
 uidmap \
 && \
 rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/google/nsjail.git && \
 cd nsjail && \
 make -j8
```

Fails like:
```
#6 2.769 subproc.cc: In function 'pid_t subproc::cloneProc(uintptr_t, int)':
#6 2.769 subproc.cc:541:2: error: 'clone_args' has no non-static data member named 'set_tid'
#6 2.769   541 |  };
#6 2.769       |  ^
```

I don't know what the "right" way to check for the presence of these members is, but checking for the existence of `CLONE_ARGS_SIZE_VER1` and `CLONE_ARGS_SIZE_VER2` works, which is what I add in this PR.

Those macros in sched.h seem to be the only indication in sched.h of the presence of these members:
https://elixir.bootlin.com/linux/v5.15/source/include/uapi/linux/sched.h

I checked that this still builds on 18.04, 20.04, and 21.04. 