### PR TITLE
Setup cgroup.subtree_control controllers when necessary in cgroupsv2

### DIFF
--- a/cgroup2.h
+++ b/cgroup2.h
@@ -32,6 +32,8 @@ namespace cgroup2 {
 bool initNsFromParent(nsjconf_t* nsjconf, pid_t pid);
 bool initNs(void);
 void finishFromParent(nsjconf_t* nsjconf, pid_t pid);
+bool setup(nsjconf_t *nsjconf);
+bool detectCgroupv2(nsjconf_t *nsjconf);
 
 }  // namespace cgroup2
 

--- a/cmdline.cc
+++ b/cmdline.cc
@@ -158,6 +158,7 @@ struct custom_option custom_opts[] = {
     { { "cgroup_cpu_parent", required_argument, NULL, 0x0833 }, "Which pre-existing cpu cgroup to use as a parent (default: 'NSJAIL')" },
     { { "cgroupv2_mount", required_argument, NULL, 0x0834}, "Location of cgroupv2 directory (default: '/sys/fs/cgroup')"},
     { { "use_cgroupv2", no_argument, NULL, 0x0835}, "Use cgroup v2"},
+    { { "detect_cgroupv2", no_argument, NULL, 0x0836}, "Use cgroupv2, if it is available. (Specify instead of use_cgroupv2)"},
     { { "iface_no_lo", no_argument, NULL, 0x700 }, "Don't bring the 'lo' interface up" },
     { { "iface_own", required_argument, NULL, 0x704 }, "Move this existing network interface into the new NET namespace. Can be specified multiple times" },
     { { "macvlan_iface", required_argument, NULL, 'I' }, "Interface which will be cloned (MACVLAN) and put inside the subprocess' namespace as 'vs'" },
@@ -473,6 +474,7 @@ std::unique_ptr<nsjconf_t> parseArgs(int argc, char* argv[]) {
 	nsjconf->cgroup_cpu_ms_per_sec = 0U;
 	nsjconf->cgroupv2_mount = "/sys/fs/cgroup";
 	nsjconf->use_cgroupv2 = false;
+	nsjconf->detect_cgroupv2 = false;
 	nsjconf->iface_lo = true;
 	nsjconf->iface_vs_ip = "0.0.0.0";
 	nsjconf->iface_vs_nm = "255.255.255.0";
@@ -911,6 +913,9 @@ std::unique_ptr<nsjconf_t> parseArgs(int argc, char* argv[]) {
 			break;
 		case 0x835:
 			nsjconf->use_cgroupv2 = true;
+			break;
+		case 0x836:
+			nsjconf->detect_cgroupv2 = true;
 			break;
 		case 'P':
 			nsjconf->kafel_file_path = optarg;

--- a/config.cc
+++ b/config.cc
@@ -266,6 +266,7 @@ static bool configParseInternal(nsjconf_t* nsjconf, const nsjail::NsJailConfig& 
 	nsjconf->cgroup_cpu_parent = njc.cgroup_cpu_parent();
 	nsjconf->cgroupv2_mount = njc.cgroupv2_mount();
 	nsjconf->use_cgroupv2 = njc.use_cgroupv2();
+	nsjconf->detect_cgroupv2 = njc.detect_cgroupv2();
 
 	nsjconf->iface_lo = !(njc.iface_no_lo());
 	for (ssize_t i = 0; i < njc.iface_own().size(); i++) {

--- a/config.proto
+++ b/config.proto
@@ -272,4 +272,7 @@ message NsJailConfig {
     /* Set this to true to forward fatal signals to the child process instead
      * of always using SIGKILL. */
     optional bool forward_signals = 94 [default = false];
+
+    /* Check whether cgroupv2 is available, and use it if available. */
+    optional bool detect_cgroupv2 = 95 [default = false];
 }

--- a/nsjail.cc
+++ b/nsjail.cc
@@ -46,6 +46,7 @@
 #include "sandbox.h"
 #include "subproc.h"
 #include "util.h"
+#include "cgroup2.h"
 
 namespace nsjail {
 
@@ -342,6 +343,19 @@ int main(int argc, char* argv[]) {
 	if (!nsjail::setTimer(nsjconf.get())) {
 		LOG_F("nsjail::setTimer() failed");
 	}
+
+	if (nsjconf->detect_cgroupv2) {
+		cgroup2::detectCgroupv2(nsjconf.get());
+		LOG_I("Detected cgroups version: %d", nsjconf->use_cgroupv2 ? 2 : 1);
+	}
+
+	if (nsjconf->use_cgroupv2) {
+		if (!cgroup2::setup(nsjconf.get())) {
+			LOG_E("Couldn't setup parent cgroup (cgroupv2)");
+			return -1;
+		}
+	}
+
 	if (!sandbox::preparePolicy(nsjconf.get())) {
 		LOG_F("Couldn't prepare sandboxing policy");
 	}

--- a/nsjail.h
+++ b/nsjail.h
@@ -163,6 +163,7 @@ struct nsjconf_t {
 	unsigned int cgroup_cpu_ms_per_sec;
 	std::string cgroupv2_mount;
 	bool use_cgroupv2;
+	bool detect_cgroupv2;
 	std::string kafel_file_path;
 	std::string kafel_string;
 	struct sock_fprog seccomp_fprog;

--- a/util.cc
+++ b/util.cc
@@ -89,16 +89,20 @@ bool writeToFd(int fd, const void* buf, size_t len) {
 	return true;
 }
 
-bool writeBufToFile(const char* filename, const void* buf, size_t len, int open_flags) {
+bool writeBufToFile(const char* filename, const void* buf, size_t len, int open_flags, bool log_errors) {
 	int fd;
 	TEMP_FAILURE_RETRY(fd = open(filename, open_flags, 0644));
 	if (fd == -1) {
-		PLOG_E("Couldn't open '%s' for writing", filename);
+		if (log_errors) {
+			PLOG_E("Couldn't open '%s' for writing", filename);
+		}
 		return false;
 	}
 
 	if (!writeToFd(fd, buf, len)) {
-		PLOG_E("Couldn't write '%zu' bytes to file '%s' (fd='%d')", len, filename, fd);
+		if (log_errors) {
+			PLOG_E("Couldn't write '%zu' bytes to file '%s' (fd='%d')", len, filename, fd);
+		}
 		close(fd);
 		if (open_flags & O_CREAT) {
 			unlink(filename);

--- a/util.h
+++ b/util.h
@@ -46,7 +46,7 @@ namespace util {
 ssize_t readFromFd(int fd, void* buf, size_t len);
 ssize_t readFromFile(const char* fname, void* buf, size_t len);
 bool writeToFd(int fd, const void* buf, size_t len);
-bool writeBufToFile(const char* filename, const void* buf, size_t len, int open_flags);
+bool writeBufToFile(const char* filename, const void* buf, size_t len, int open_flags, bool log_errors = true);
 bool createDirRecursively(const char* dir);
 std::string* StrAppend(std::string* str, const char* format, ...)
     __attribute__((format(printf, 2, 3)));


### PR DESCRIPTION
This commit adds extra setup when cgroupsv2 is enabled. In particular, we make sure that the root cgroup (whatever `cgroupv2_mount` is set to) has setup cgroup.subtree_control with the controllers we need.

If the necessary controller are not listed, we have to move all processes out of the root cgroup before we can change this (the 'no internal processes' rule: https://unix.stackexchange.com/a/713343). Currently this handles the case where the nsjail process is the only process in the cgroup. It seems like this would be relatively rare, but since nsjail is frequently the root process in a Docker container (e.g. for hosting CTF challenges), I think this case is common enough to make it worth implementing.

This also adds `--detect_cgroupv2`, which will attempt to detect whether `--cgroupv2_mount` is a valid cgroupv2 mount, and will set`use_cgroupv2` accordingly. This is useful in containerized environments where you may not know the configuration ahead of time.

References:
https://github.com/redpwn/jail/blob/master/internal/cgroup/cgroup2.go

See #196 