### PR TITLE
fix potentially missing some signals when --forward_signals is set

### DIFF
--- a/subproc.cc
+++ b/subproc.cc
@@ -405,14 +405,17 @@ int reapProc(nsjconf_t* nsjconf) {
 	return rv;
 }
 
-void killAndReapAll(nsjconf_t* nsjconf, int signal) {
+void sendSignalAll(nsjconf_t* nsjconf, int signal) {
 	while (!nsjconf->pids.empty()) {
 		pid_t pid = nsjconf->pids.begin()->first;
-		if (kill(pid, signal) == 0) {
-			reapProc(nsjconf, pid, true);
-		} else {
-			removeProc(nsjconf, pid);
-		}
+		kill(pid, signal);
+	}
+}
+
+void reapAll(nsjconf_t* nsjconf) {
+	while (!nsjconf->pids.empty()) {
+		pid_t pid = nsjconf->pids.begin()->first;
+		reapProc(nsjconf, pid, true);
 	}
 }
 

--- a/subproc.h
+++ b/subproc.h
@@ -37,7 +37,8 @@ namespace subproc {
 pid_t runChild(nsjconf_t* nsjconf, int listen_fd, int fd_in, int fd_out, int fd_err);
 int countProc(nsjconf_t* nsjconf);
 void displayProc(nsjconf_t* nsjconf);
-void killAndReapAll(nsjconf_t* nsjconf, int signal);
+void sendSignalAll(nsjconf_t* nsjconf, int signal);
+void reapAll(nsjconf_t* nsjconf);
 /* Returns the exit code of the first failing subprocess, or 0 if none fail */
 int reapProc(nsjconf_t* nsjconf);
 int systemExe(const std::vector<std::string>& args, char** env);


### PR DESCRIPTION
previously code dealing with sigFatal assumed that the value is either 0 or a value representing a single type of signal