### PR TITLE
Correct man page formatting error

### DIFF
--- a/nsjail.1
+++ b/nsjail.1
@@ -196,7 +196,7 @@ List of mountpoints to be mounted as tmpfs (R/W) inside the container. Can be sp
 \fB\-\-mount\fR|\fB\-m\fR VALUE
 Arbitrary mount, format src:dst:fs_type:options
 .TP
-\fB\-\-symlink\fR|\f\B\-s\fR VALUE
+\fB\-\-symlink\fR|\fB\-s\fR VALUE
 Symlink, format src:dst
 .TP
 \fB\-\-disable_proc\fR


### PR DESCRIPTION
While working on packaging for Debian, one of the linting tools pointed out this very minor error in the man page.