### PR TITLE
Cast MS_RDONLY to uintptr_t to fix build error on Fedora 43 (Glibc 2.42) due to unsigned enum

### DIFF
--- a/mnt.cc
+++ b/mnt.cc
@@ -547,7 +547,7 @@ static bool initCloneNs(nsj_t* nsj) {
 
 	std::vector<mount_t> mounted_mpts;
 	for (const auto& p : nsj->njc.mount()) {
-		uintptr_t flags = (p.rw() ? 0 : MS_RDONLY);
+		uintptr_t flags = (p.rw() ? 0 : (uintptr_t)MS_RDONLY);
 		if (p.is_bind()) {
 			flags |= (MS_BIND | MS_REC | MS_PRIVATE);
 		}


### PR DESCRIPTION
This PR fixes a build failure on Fedora 43 (and likely on other systems with Glibc 2.42+) where `sys/mount.h` enum is unsigned. In Glibc 2.42, `MS_NOUSER` was updated to `1U << 31` from `1 << 31` to fix integer overflow warnings ([Bug 32708](https://sourceware.org/bugzilla/show_bug.cgi?id=32708), commit: [3263675250cbcbbcc76ede4f7c660418bd345a11](https://sourceware.org/git/gitweb.cgi?p=glibc.git;a=commit;h=3263675250cbcbbcc76ede4f7c660418bd345a11)). This change forces the entire sys/mount.h enum (which includes MS_RDONLY) to be unsigned, which causes the build to fail in `mnt.cc`.

Build errors:
```
mnt.cc:550:43: error: enumerated and non-enumerated type in conditional expression [-Werror=extra]
  550 |                 uintptr_t flags = (p.rw() ? 0 : MS_RDONLY);
      |                                           ^
cc1plus: all warnings being treated as errors
```

Casting `MS_RDONLY` to `uintptr_t` fixes this issue by ensuring type compatibility,

Tested on Fedora 43 (Glibc 2.42, Unsigned enum) and on Debian 13 (Glibc 2.41, Signed enum). Tested also on Arch Linux with Glibc 2.42 to confirm its not Fedora only issue. 

Glibc 2.42 release notes: https://inbox.sourceware.org/libc-announce/5906001.DvuYhMxLoT@pinacolada/T/