### PR TITLE
Fix ESRCH in sched_setaffinity due to glibc TID caching with clone3

### DIFF
--- a/cpu.cc
+++ b/cpu.cc
@@ -25,6 +25,7 @@
 #include <sched.h>
 #include <stdint.h>
 #include <string.h>
+#include <sys/syscall.h>
 #include <unistd.h>
 
 #include <memory>
@@ -127,7 +128,7 @@ bool initCpu(nsj_t* nsj) {
 	    (size_t)CPU_COUNT(new_mask.get()), available_cpus, (size_t)CPU_COUNT(orig_mask.get()),
 	    listCpusInSet(orig_mask.get()).c_str());
 
-	if (sched_setaffinity(0, CPU_ALLOC_SIZE(CPU_SETSIZE), new_mask.get()) == -1) {
+	if (util::syscall(__NR_sched_setaffinity, 0, CPU_ALLOC_SIZE(CPU_SETSIZE), (uintptr_t)new_mask.get()) == -1) {
 		PLOG_W("sched_setaffinity(mask=%s size=%zu max_cpus=%zu (CPU_COUNT=%zu)) failed",
 		    listCpusInSet(new_mask.get()).c_str(), (size_t)CPU_ALLOC_SIZE(CPU_SETSIZE),
 		    (size_t)nsj->njc.max_cpus(), (size_t)CPU_COUNT(new_mask.get()));


### PR DESCRIPTION
When nsjail creates a new process in a new PID namespace (CLONE_NEWPID) using the direct kernel syscall clone/clone3 (introduced in d1f332b), glibc's internal PID/TID cache is not updated for the child process.

As a result, calling the glibc wrapper `sched_setaffinity(0, ...)` inside the child process causes glibc to inadvertently pass the cached parent's TID to the kernel instead of 0 (current thread). Since the parent's TID does not exist within the new PID namespace, the kernel returns ESRCH (No such process).

This commit fixes the issue by bypassing the glibc wrapper and invoking the `sched_setaffinity` syscall directly via `util::syscall`. This ensures that `0` is passed accurately to the kernel, referring to the current thread.