### PR TITLE
net: fix double-free of nl_cache in initParent error paths

### DIFF
--- a/net.cc
+++ b/net.cc
@@ -466,12 +466,10 @@ bool initParent(nsj_t* nsj, pid_t pid, int pipefd) {
 
 	for (const auto& iface : nsj->njc.iface_own()) {
 		if (!moveToNs(iface, sk, link_cache, pid)) {
-			nl_cache_free(link_cache);
 			return false;
 		}
 	}
 	if (!nsj->njc.macvlan_iface().empty() && !cloneIface(nsj, sk, link_cache, pid)) {
-		nl_cache_free(link_cache);
 		return false;
 	}
 


### PR DESCRIPTION
## Summary

`initParent` in `net.cc` registers a `defer { nl_cache_free(link_cache); }` RAII guard that ensures `link_cache` is freed on all exit paths. However, the error returns inside the `iface_own` loop and the `cloneIface` block also called `nl_cache_free(link_cache)` explicitly, resulting in a double-free when `moveToNs` or `cloneIface` fails.

### Reproduction

With a configuration that includes `iface_own` set to a nonexistent interface, nsjail calls `moveToNs`, which fails because `rtnl_link_get_by_name` returns `NULL` for the unknown interface. The explicit `nl_cache_free` fires, then the `defer` guard fires again on `return false` — double-free.

Under ASan:
```
AddressSanitizer:DEADLYSIGNAL
ERROR: AddressSanitizer: SEGV on unknown address
    in nl_cache_clear (libnl-3.so.200)
    in nl_cache_free (libnl-3.so.200)
```

### Fix

Remove the two redundant explicit `nl_cache_free(link_cache)` calls from the error paths. The `defer` guard is sufficient to free `link_cache` on all code paths.