### PR TITLE
unotify: check return value of TextFormat::PrintToString

### DIFF
--- a/unotify/stats.cc
+++ b/unotify/stats.cc
@@ -170,7 +170,10 @@ void printStats(nsj_t* nsj) {
 	}
 
 	std::string text_report;
-	google::protobuf::TextFormat::PrintToString(report_pb, &text_report);
+	if (!google::protobuf::TextFormat::PrintToString(report_pb, &text_report)) {
+		LOG_W("Failed to format unotify report");
+		return;
+	}
 
 	LOG_I("unotify report:\n%s", text_report.c_str());
 


### PR DESCRIPTION
The protobuf API marks PrintToString as `nodiscard`, so ignoring its return value broke the build under `-Werror`:

```
unotify/stats.cc: In function ‘void unotify::printStats(nsj_t*)’:
unotify/stats.cc:173:52: error: ignoring return value of ‘static bool google::protobuf::TextFormat::PrintToString(const google::protobuf::Message&, std::string*)’, declared with attribute ‘nodiscard’ [[-Werror=unused-result](https://gcc.gnu.org/onlinedocs/gcc-16.1.0/gcc/Warning-Options.html#index-Wno-unused-result)]
  173 |         google::protobuf::TextFormat::PrintToString(report_pb, &text_report);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
In file included from unotify/stats.cc:4:
/usr/include/google/protobuf/text_format.h:121:51: note: declared here
  121 |   PROTOBUF_FUTURE_ADD_EARLY_NODISCARD static bool PrintToString(
      |                                                   ^~~~~~~~~~~~~
```

Check the result and bail out with a warning if formatting fails.