### PR TITLE
contain: add core scheduling support (PR_SCHED_CORE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ docker run --privileged --rm -it nsjail nsjail --user 99999 --group 99999 --chro
 --seccomp_string POLICY   Inline seccomp policy
 --cap CAP_NAME            Retain capability (can specify multiple)
 --keep_caps               Retain all capabilities
+--use_core_scheduling     Enable core scheduling (SMT-level isolation, requires kernel >= 5.14)
 
 # Networking
 --iface_own IFACE         Move interface into jail

--- a/cmdline.cc
+++ b/cmdline.cc
@@ -174,6 +174,7 @@ static const struct custom_option custom_opts[] = {
     { { "macvlan_vs_mo", required_argument, nullptr, 0x706 }, "Mode of the 'vs' interface. Can be either 'private', 'vepa', 'bridge' or 'passthru' (default: 'private')" },
     { { "disable_tsc", no_argument, nullptr, 0x707 }, "Disable rdtsc and rdtscp instructions. WARNING: To make it effective, you also need to forbid `prctl(PR_SET_TSC, PR_TSC_ENABLE, ...)` in seccomp rules! (x86 and x86_64 only). Dynamic binaries produced by GCC seem to rely on RDTSC, but static ones should work." },
     { { "forward_signals", no_argument, nullptr, 0x708 }, "Forward fatal signals to the child process instead of always using SIGKILL." },
+    { { "use_core_scheduling", no_argument, nullptr, 0x709 }, "Enable Linux core scheduling (PR_SCHED_CORE, requires kernel >= 5.14)" },
     { { "user_net", no_argument, nullptr, 0x70A }, "Enable user-mode networking (nstun backend)" },
     { { "oom_score_adj", required_argument, nullptr, 0x800 }, "OOM score adjustment for the sandbox (-1000 to 1000) (default: not set)" },
 };
@@ -292,7 +293,7 @@ void logParams(nsj_t* nsj) {
 	      "max_conns:%u, max_conns_per_ip:%u, time_limit:%u, daemonize:%s, clone_newnet:%s, "
 	      "clone_newuser:%s, clone_newns:%s, clone_newpid:%s, clone_newipc:%s, "
 	      "clone_newuts:%s, cgroupv2:%s, keep_caps:%s, "
-	      "disable_no_new_privs:%s, max_cpus:%u",
+	      "disable_no_new_privs:%s, max_cpus:%u, use_core_scheduling:%s",
 	    nsj->njc.hostname().c_str(), QC(nsj->chroot),
 	    nsj->njc.exec_bin().path().empty() ? nsj->argv[0].c_str()
 					       : nsj->njc.exec_bin().path().c_str(),
@@ -302,7 +303,8 @@ void logParams(nsj_t* nsj) {
 	    logYesNo(nsj->njc.clone_newns()), logYesNo(nsj->njc.clone_newpid()),
 	    logYesNo(nsj->njc.clone_newipc()), logYesNo(nsj->njc.clone_newuts()),
 	    logYesNo(nsj->njc.use_cgroupv2()), logYesNo(nsj->njc.keep_caps()),
-	    logYesNo(nsj->njc.disable_no_new_privs()), nsj->njc.max_cpus());
+	    logYesNo(nsj->njc.disable_no_new_privs()), nsj->njc.max_cpus(),
+	    logYesNo(nsj->njc.use_core_scheduling()));
 
 	for (const auto& p : nsj->njc.mount()) {
 		LOG_I("%s: %s", p.is_symlink() ? "Symlink" : "Mount",
@@ -914,6 +916,9 @@ std::unique_ptr<nsj_t> parseArgs(int argc, char* argv[]) {
 			break;
 		case 0x708:
 			nsj->njc.set_forward_signals(true);
+			break;
+		case 0x709:
+			nsj->njc.set_use_core_scheduling(true);
 			break;
 		case 0x801:
 			nsj->njc.set_cgroup_mem_max((size_t)strtoull(optarg, NULL, 0));

--- a/config.proto
+++ b/config.proto
@@ -224,6 +224,8 @@ message NsJailConfig {
 	optional bool seccomp_unotify = 99 [default = false];
 	/* File to write the seccomp_unotify report to */
 	optional string seccomp_unotify_report = 100;
+	/* Use Linux core scheduling (PR_SCHED_CORE, requires kernel >= 5.14) */
+	optional bool use_core_scheduling = 101 [default = false];
 
 	/* If > 0, maximum cumulative size of RAM used inside any jail */
 	optional uint64 cgroup_mem_max = 71 [default = 0]; /* In bytes */

--- a/contain.cc
+++ b/contain.cc
@@ -46,6 +46,7 @@
 #include "cpu.h"
 #include "logs.h"
 #include "macros.h"
+#include "missing_defs.h"
 #include "mnt.h"
 #include "net.h"
 #include "pid.h"
@@ -135,6 +136,19 @@ static bool containInitMountNs(nsj_t* nsj) {
 
 static bool containCPU(nsj_t* nsj) {
 	return cpu::initCpu(nsj);
+}
+
+static bool containCoreSched(nsj_t* nsj) {
+	if (!nsj->njc.use_core_scheduling()) {
+		return true;
+	}
+	if (prctl(PR_SCHED_CORE, PR_SCHED_CORE_CREATE, 0, PR_SCHED_CORE_SCOPE_THREAD_GROUP, 0) ==
+	    -1) {
+		PLOG_E("prctl(PR_SCHED_CORE_CREATE) failed");
+		return false;
+	}
+	LOG_D("Core scheduling enabled for this jail");
+	return true;
 }
 
 static bool containTSC(nsj_t* nsj) {
@@ -377,6 +391,7 @@ bool containProc(nsj_t* nsj) {
 	/* */
 	/* As non-root */
 	RETURN_ON_FAILURE(containCPU(nsj));
+	RETURN_ON_FAILURE(containCoreSched(nsj));
 	RETURN_ON_FAILURE(containTSC(nsj));
 	RETURN_ON_FAILURE(containSetLimits(nsj));
 	RETURN_ON_FAILURE(containPrepareEnv(nsj));

--- a/missing_defs.h
+++ b/missing_defs.h
@@ -491,6 +491,12 @@ struct mount_attr {
 #define PR_CAP_AMBIENT_CLEAR_ALL 4
 #endif /* !defined(PR_CAP_AMBIENT) */
 
+#if !defined(PR_SCHED_CORE)
+#define PR_SCHED_CORE 62
+#define PR_SCHED_CORE_CREATE 1
+#define PR_SCHED_CORE_SCOPE_THREAD_GROUP 1
+#endif /* !defined(PR_SCHED_CORE) */
+
 /* =========================================================================
  * SECCOMP_FILTER_FLAG_* flags
  * ========================================================================= */


### PR DESCRIPTION
Closes #198

Adds `--use_core_scheduling` flag that calls `prctl(PR_SCHED_CORE_CREATE)` in the child process, giving each jail its 
own SMT scheduling group. This prevents a jailed process from sharing a physical CPU core with processes outside the 
jail, mitigating L1TF/MDS side-channel attacks in multi-tenant environments.

Changes:
- `config.proto`: new `use_core_scheduling` bool field (field 101)
- `cmdline.cc`: `--use_core_scheduling` CLI flag; included in startup log via `logParams()`
- `contain.cc`: `containCoreSched()`, called after `containDropPrivs()` — `PR_SCHED_CORE_CREATE` does not require 
capabilities
- `missing_defs.h`: fallback defines for `PR_SCHED_CORE` / `PR_SCHED_CORE_CREATE` / `PR_SCHED_CORE_SCOPE_THREAD_GROUP` 
for builds against older kernel headers
- `README.md`: flag documented in the security options section

Requires Linux kernel >= 5.14. Disabled by default; no behavior change for existing configs.