### PR TITLE
Validate mount destinations before building mount trees

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,9 @@ endif
 	$(call run_test, ./nsjail $(OLD_EF) -q -Mo --chroot / -m none:/tmp:tmpfs:ro --user 99999 --group 99999 -- /bin/bash -c 'touch /tmp/nsjail_test || exit 77', 77)
 	$(call run_test, ./nsjail $(OLD_EF) -q -Mo --chroot / -R /tmp --user 99999 --group 99999 -- /bin/bash -c 'touch /tmp/nsjail_test || exit 77', 77)
 	$(call run_test, ./nsjail $(OLD_EF) -q -Mo --chroot / -B /tmp --user 99999 --group 99999 -- /bin/bash -c 'touch /tmp/nsjail_test && rm -f /tmp/nsjail_test', 0)
+	$(call run_test, rm -f /tmp/nsjail_mnt_escape_old, 0)
+	$(call run_test, ./nsjail $(OLD_EF) -q -Mo --chroot / --disable_proc --symlink /etc/passwd:/../../../../../tmp/nsjail_mnt_escape_old -- /bin/true, 255)
+	$(call run_test, test ! -e /tmp/nsjail_mnt_escape_old, 0)
 	$(call run_test, ./nsjail $(OLD_EF) -q -Mo --chroot / --user 99999 --group 99999 -- /bin/bash -c 'touch /run/user/$(UID)/nsjail_test2 && exit 77', 77) # --rw (or lack of thereof) doesn't change already mounted tmpfs
 	$(call run_test, ./nsjail $(OLD_EF) -q -Mo --chroot / --user 99999 --group 99999 --rw -- /bin/bash -c 'touch /run/user/$(UID)/nsjail_test2 && exit 77', 77) # --rw (or lack of thereof) doesn't affect already mounted tmpfs
 	$(call run_test, rm -f /run/user/$(UID)/nsjail_test2, 0)
@@ -220,6 +223,9 @@ endif
 	$(call run_test, ./nsjail $(NEW_EF) -q -Mo --chroot / -m none:/tmp:tmpfs:ro --user 99999 --group 99999 -- /bin/bash -c 'touch /tmp/nsjail_test || exit 77', 77)
 	$(call run_test, ./nsjail $(NEW_EF) -q -Mo --chroot / -R /tmp --user 99999 --group 99999 -- /bin/bash -c 'touch /tmp/nsjail_test || exit 77', 77)
 	$(call run_test, ./nsjail $(NEW_EF) -q -Mo --chroot / -B /tmp --user 99999 --group 99999 -- /bin/bash -c 'touch /tmp/nsjail_test && rm -f /tmp/nsjail_test', 0)
+	$(call run_test, rm -f /tmp/nsjail_mnt_escape_new, 0)
+	$(call run_test, ./nsjail $(NEW_EF) -q -Mo --chroot / --disable_proc --symlink /etc/passwd:/../../../../../tmp/nsjail_mnt_escape_new -- /bin/true, 255)
+	$(call run_test, test ! -e /tmp/nsjail_mnt_escape_new, 0)
 	$(call run_test, ./nsjail $(NEW_EF) -q -Mo --chroot / --user 99999 --group 99999 -- /bin/bash -c 'touch /run/user/$(UID)/nsjail_test2 || exit 77', 77)
 	$(call run_test, ./nsjail $(NEW_EF) -q -Mo --chroot / --user 99999 --group 99999 --rw -- /bin/bash -c 'touch /run/user/$(UID)/nsjail_test2 && exit 77', 77)
 	$(call run_test, rm -f /run/user/$(UID)/nsjail_test2, 0)

--- a/mnt.cc
+++ b/mnt.cc
@@ -108,6 +108,20 @@ const std::string flagsToStr(unsigned long flags) {
 	return res;
 }
 
+bool isMountDestSafe(const std::string& dst) {
+	if (dst.find('\0') != std::string::npos) {
+		LOG_W("Mount destination contains a NUL byte: %s", QC(dst));
+		return false;
+	}
+	for (const auto& component : util::strSplit(dst, '/')) {
+		if (component == "..") {
+			LOG_W("Mount destination escapes the jail root: %s", QC(dst));
+			return false;
+		}
+	}
+	return true;
+}
+
 const std::string describeMountPt(const nsjail::MountPt& mpt) {
 	std::string descr;
 

--- a/mnt.h
+++ b/mnt.h
@@ -74,6 +74,7 @@ bool initNs(nsj_t* nsj);
 std::unique_ptr<std::string> findWorkDir(nsj_t* nsj, const char* purpose);
 const std::string describeMountPt(const nsjail::MountPt& mpt);
 const std::string flagsToStr(unsigned long flags);
+bool isMountDestSafe(const std::string& dst);
 
 }  // namespace mnt
 

--- a/mnt_legacy.cc
+++ b/mnt_legacy.cc
@@ -196,6 +196,10 @@ static bool mountWithDynamicContent(
 static bool mountSinglePoint(mount_t* mpt, const char* newroot, const char* tmpdir) {
 	LOG_D("Mounting (legacy): %s", mnt::describeMountPt(*mpt->mpt).c_str());
 
+	if (!mnt::isMountDestSafe(mpt->dst)) {
+		return false;
+	}
+
 	const std::string dstpath = std::string(newroot) + "/" + mpt->dst;
 	std::string srcpath = mpt->src.empty() ? "none" : mpt->src;
 

--- a/mnt_newapi.cc
+++ b/mnt_newapi.cc
@@ -411,6 +411,10 @@ static bool doBindMountAt(mount_t* mpt, int root_fd, const char* rel_dst) {
 static bool mountSinglePointAt(mount_t* mpt, int root_fd) {
 	LOG_D("Mounting (new API): %s", mnt::describeMountPt(*mpt->mpt).c_str());
 
+	if (!mnt::isMountDestSafe(mpt->dst)) {
+		return false;
+	}
+
 	const char* rel_dst = util::stripLeadingSlashes(mpt->dst.c_str());
 	if (!rel_dst[0]) {
 		rel_dst = ".";


### PR DESCRIPTION
## Summary

Mount destinations are documented as paths inside the jail, but the old and new mount backends accepted destinations containing parent-directory components. Both backends use those strings while constructing the mount tree, before the final jailed process runs.

This change rejects mount destinations that contain NUL bytes or any `..` path component before either backend creates directories, files, symlinks, or mounts. Valid absolute and relative destinations continue to work.

## Validation

- `make -j2`
- `git diff --check`
- `./nsjail -q -Mo --experimental_mnt old --chroot / --disable_proc --symlink /etc/passwd:/../../../../../tmp/nsjail_mnt_escape_old -- /bin/true` now exits `255` and does not create `/tmp/nsjail_mnt_escape_old`
- `./nsjail -q -Mo --experimental_mnt new --chroot / --disable_proc --symlink /etc/passwd:/../../../../../tmp/nsjail_mnt_escape_new -- /bin/true` now exits `255` and does not create `/tmp/nsjail_mnt_escape_new`
- Valid in-jail symlink destinations still exit `0` with both `--experimental_mnt old` and `--experimental_mnt new`
- Invalid `--tmpfsmount` destinations are rejected and do not create host directories with both mount backends