### PR TITLE
Harden pasta helper execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,12 @@ test: $(BIN)
 	$(call run_test, ./nsjail --config tests/basic.cfg -q -t 2 -- /bin/bash -c 'strace -o /dev/null /bin/true && exit 77', 77)
 	$(call run_test, ./nsjail --config tests/pasta-nat.cfg -q -t 3 -- /bin/bash -c 'sleep 0.2; ping -W 1 -c 1 8.8.8.8 && exit 77', 77)
 	$(call run_test, ./nsjail --config tests/pasta-port-mappings.cfg -q -t 3 -- /bin/bash -c 'sleep 0.2; { netstat -tan | grep LISTEN; } && exit 77', 77)
+	rm -f /tmp/nsjail_pasta_env_test /tmp/nsjail_fake_pasta
+	printf '#!/bin/sh\necho env-path-executed > /tmp/nsjail_pasta_env_test\nexit 0\n' > /tmp/nsjail_fake_pasta
+	chmod +x /tmp/nsjail_fake_pasta
+	NSJAIL_PASTA_PATH=/tmp/nsjail_fake_pasta ./nsjail --config tests/pasta-nat.cfg -q -t 1 -- /bin/true >/dev/null 2>&1 || true
+	test ! -e /tmp/nsjail_pasta_env_test
+	rm -f /tmp/nsjail_pasta_env_test /tmp/nsjail_fake_pasta
 
 ifeq ($(NL3_EXISTS), yes)
 	# --- Traffic rules tests ---

--- a/net.cc
+++ b/net.cc
@@ -67,6 +67,16 @@
 #define F_SEAL_FUTURE_WRITE 0x0010
 #endif /* !defined(F_SEAL_FUTURE_WRITE) */
 
+static char* const kPastaEnv[] = {const_cast<char*>("PATH=/usr/sbin:/usr/bin:/sbin:/bin"), nullptr};
+
+static const char* const kPastaPaths[] = {
+	"/usr/bin/pasta",
+	"/usr/local/bin/pasta",
+	"/bin/pasta",
+	"/sbin/pasta",
+	nullptr,
+};
+
 /* Embed pasta inside this binary */
 // clang-format off
 __asm__("\n"
@@ -121,7 +131,24 @@ static int getPastaFd() {
 	return fd;
 }
 
-extern char** environ;
+static int openPastaFd() {
+	int fd = getPastaFd();
+	if (fd != -1) {
+		return fd;
+	}
+
+	for (const char* const* path = kPastaPaths; *path != nullptr; path++) {
+		fd = open(*path, O_PATH | O_CLOEXEC);
+		if (fd != -1) {
+			return fd;
+		}
+		if (errno != ENOENT && errno != ENOTDIR) {
+			PLOG_D("open('%s', O_PATH | O_CLOEXEC)", *path);
+		}
+	}
+
+	return -1;
+}
 
 namespace net {
 
@@ -353,11 +380,7 @@ static void pastaProcess(nsj_t* nsj, int pid, int err_pipe) {
 		close(nullfd);
 	}
 
-	int pasta_fd = getPastaFd();
-	const char* pasta_path = getenv("NSJAIL_PASTA_PATH");
-	if (pasta_path == NULL) {
-		pasta_path = argv[0];
-	}
+	int pasta_fd = openPastaFd();
 
 	util::makeRangeCOE(STDERR_FILENO + 1, ~0U);
 
@@ -365,14 +388,13 @@ static void pastaProcess(nsj_t* nsj, int pid, int err_pipe) {
 	int err = 0;
 	if (pasta_fd != -1) {
 		util::syscall(__NR_execveat, pasta_fd, (uintptr_t)"", (uintptr_t)argv.data(),
-		    (uintptr_t)environ, AT_EMPTY_PATH);
+		    (uintptr_t)kPastaEnv, AT_EMPTY_PATH);
 		err = errno;
 		PLOG_W("execveat(pasta_fd=%d, AT_EMPTY_PATH)", pasta_fd);
 
 	} else {
-		execvpe(pasta_path, (char* const*)argv.data(), environ);
-		err = errno;
-		PLOG_W("execvpe('%s')", pasta_path);
+		err = ENOENT;
+		LOG_W("Cannot find pasta binary in trusted system paths");
 	}
 
 	util::writeToFd(err_pipe, &err, sizeof(err));


### PR DESCRIPTION
Summary:
- stop resolving the parent-side PASTA helper from inherited NSJAIL_PASTA_PATH/PATH
- execute embedded or fixed system-path pasta via fd with a minimal helper environment
- add a regression check that an inherited fake NSJAIL_PASTA_PATH is not executed

Security rationale:
When PASTA user networking is enabled, nsjail spawns the pasta helper from the parent-side setup path before the jailed child clears and rebuilds its environment. Previously, non-embedded builds called execvpe() using the inherited process environment. A launcher that runs nsjail with elevated privileges while preserving attacker-controlled environment variables could therefore let the attacker steer the helper path, PATH lookup, or dynamic-loader environment before sandbox setup completes.

This patch keeps support for embedded pasta, but otherwise opens pasta from fixed system paths and invokes it through execveat() with a minimal environment.

Validation:
- make -j2
- git diff --check
- reproduced the pre-fix behavior with NSJAIL_PASTA_PATH pointing at a fake helper that wrote /tmp/nsjail_pasta_env_poc as uid 0
- confirmed the patched default build leaves that marker absent
- built a validation-only embedded helper with PASTA_BIN_PATH and confirmed embedded helper execution still works while inherited variables are not passed

I could not run the existing full PASTA integration tests end-to-end in this environment because there is no trusted system pasta binary installed.