### PR TITLE
mnt: make recursive read-only binds truly recursive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,8 @@ endif
 	$(call run_test, ./nsjail $(OLD_EF) -q -Mo --chroot / -m none:/tmp:tmpfs:rw --user 99999 --group 99999 -- /bin/bash -c 'touch /tmp/nsjail_test && rm -f /tmp/nsjail_test', 0)
 	$(call run_test, ./nsjail $(OLD_EF) -q -Mo --chroot / -m none:/tmp:tmpfs:ro --user 99999 --group 99999 -- /bin/bash -c 'touch /tmp/nsjail_test || exit 77', 77)
 	$(call run_test, ./nsjail $(OLD_EF) -q -Mo --chroot / -R /tmp --user 99999 --group 99999 -- /bin/bash -c 'touch /tmp/nsjail_test || exit 77', 77)
+	$(call run_test, ./nsjail $(OLD_EF) -q -Mo --rw --chroot / -R /dev --user 99999 --group 99999 -- /bin/bash -c 'if touch /dev/shm/nsjail_nested_test; then rm -f /dev/shm/nsjail_nested_test; exit 77; fi', 0)
+	$(call run_test, ./nsjail $(OLD_EF) -q -Mo --rw --chroot / -R /dev -B /dev/shm --user 99999 --group 99999 -- /bin/bash -c 'touch /dev/shm/nsjail_child_override && rm -f /dev/shm/nsjail_child_override', 0)
 	$(call run_test, ./nsjail $(OLD_EF) -q -Mo --chroot / -B /tmp --user 99999 --group 99999 -- /bin/bash -c 'touch /tmp/nsjail_test && rm -f /tmp/nsjail_test', 0)
 	$(call run_test, ./nsjail $(OLD_EF) -q -Mo --chroot / --user 99999 --group 99999 -- /bin/bash -c 'touch /run/user/$(UID)/nsjail_test2 && exit 77', 77) # --rw (or lack of thereof) doesn't change already mounted tmpfs
 	$(call run_test, ./nsjail $(OLD_EF) -q -Mo --chroot / --user 99999 --group 99999 --rw -- /bin/bash -c 'touch /run/user/$(UID)/nsjail_test2 && exit 77', 77) # --rw (or lack of thereof) doesn't affect already mounted tmpfs
@@ -219,6 +221,8 @@ endif
 	$(call run_test, ./nsjail $(NEW_EF) -q -Mo --chroot / -m none:/tmp:tmpfs:rw --user 99999 --group 99999 -- /bin/bash -c 'touch /tmp/nsjail_test && rm -f /tmp/nsjail_test', 0)
 	$(call run_test, ./nsjail $(NEW_EF) -q -Mo --chroot / -m none:/tmp:tmpfs:ro --user 99999 --group 99999 -- /bin/bash -c 'touch /tmp/nsjail_test || exit 77', 77)
 	$(call run_test, ./nsjail $(NEW_EF) -q -Mo --chroot / -R /tmp --user 99999 --group 99999 -- /bin/bash -c 'touch /tmp/nsjail_test || exit 77', 77)
+	$(call run_test, ./nsjail $(NEW_EF) -q -Mo --rw --chroot / -R /dev --user 99999 --group 99999 -- /bin/bash -c 'if touch /dev/shm/nsjail_nested_test; then rm -f /dev/shm/nsjail_nested_test; exit 77; fi', 0)
+	$(call run_test, ./nsjail $(NEW_EF) -q -Mo --rw --chroot / -R /dev -B /dev/shm --user 99999 --group 99999 -- /bin/bash -c 'touch /dev/shm/nsjail_child_override && rm -f /dev/shm/nsjail_child_override', 0)
 	$(call run_test, ./nsjail $(NEW_EF) -q -Mo --chroot / -B /tmp --user 99999 --group 99999 -- /bin/bash -c 'touch /tmp/nsjail_test && rm -f /tmp/nsjail_test', 0)
 	$(call run_test, ./nsjail $(NEW_EF) -q -Mo --chroot / --user 99999 --group 99999 -- /bin/bash -c 'touch /run/user/$(UID)/nsjail_test2 || exit 77', 77)
 	$(call run_test, ./nsjail $(NEW_EF) -q -Mo --chroot / --user 99999 --group 99999 --rw -- /bin/bash -c 'touch /run/user/$(UID)/nsjail_test2 && exit 77', 77)

--- a/mnt.cc
+++ b/mnt.cc
@@ -26,6 +26,7 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <limits.h>
+#include <linux/mount.h>
 #include <linux/sched.h>
 #include <sched.h>
 #include <signal.h>
@@ -106,6 +107,26 @@ const std::string flagsToStr(unsigned long flags) {
 	}
 
 	return res;
+}
+
+bool remountRecursiveReadOnly(const mount_t& mpt) {
+#if defined(__NR_mount_setattr) && defined(MOUNT_ATTR_RDONLY) && defined(AT_RECURSIVE)
+	struct mount_attr attr = {};
+	attr.attr_set = MOUNT_ATTR_RDONLY;
+
+	LOG_D("Remounting '%s' recursively read-only", mpt.dst.c_str());
+	if (util::syscall(__NR_mount_setattr, (uintptr_t)AT_FDCWD,
+		(uintptr_t)mpt.dst.c_str(), (uintptr_t)AT_RECURSIVE, (uintptr_t)&attr,
+		sizeof(attr)) < 0) {
+		PLOG_W("mount_setattr('%s', AT_RECURSIVE, flags=0x%" PRIx64 ")",
+		    mpt.dst.c_str(), (uint64_t)attr.attr_set);
+		return false;
+	}
+	return true;
+#else
+	LOG_W("Recursive read-only bind mounts require mount_setattr(2) support");
+	return false;
+#endif
 }
 
 const std::string describeMountPt(const nsjail::MountPt& mpt) {
@@ -327,7 +348,7 @@ static bool initCloneNs(nsj_t* nsj) {
 		} else {
 			success = legacy::remountPt(mpt);
 		}
-		if (!success && mpt.mpt->mandatory()) {
+		if (!success) {
 			return false;
 		}
 	}

--- a/mnt.h
+++ b/mnt.h
@@ -74,6 +74,7 @@ bool initNs(nsj_t* nsj);
 std::unique_ptr<std::string> findWorkDir(nsj_t* nsj, const char* purpose);
 const std::string describeMountPt(const nsjail::MountPt& mpt);
 const std::string flagsToStr(unsigned long flags);
+bool remountRecursiveReadOnly(const mount_t& mpt);
 
 }  // namespace mnt
 

--- a/mnt_legacy.cc
+++ b/mnt_legacy.cc
@@ -267,6 +267,10 @@ bool remountPt(mnt::mount_t& mpt) {
 	if (!mpt.mounted || mpt.mpt->is_symlink()) {
 		return true;
 	}
+	if ((mpt.flags & MS_RDONLY) && (mpt.flags & MS_BIND) && (mpt.flags & MS_REC) &&
+	    mpt.is_dir && !mnt::remountRecursiveReadOnly(mpt)) {
+		return false;
+	}
 
 	struct statvfs vfs;
 	if (TEMP_FAILURE_RETRY(statvfs(mpt.dst.c_str(), &vfs)) == -1) {

--- a/mnt_newapi.cc
+++ b/mnt_newapi.cc
@@ -556,6 +556,11 @@ bool remountPt(mnt::mount_t& mpt) {
 	close(mpt.fd);
 	mpt.fd = -1;
 
+	if ((mpt.flags & MS_RDONLY) && (mpt.flags & MS_BIND) && (mpt.flags & MS_REC) &&
+	    mpt.is_dir && !mnt::remountRecursiveReadOnly(mpt)) {
+		return false;
+	}
+
 	if (!remountWithLegacyMount(mpt)) {
 		LOG_W("Failed to apply final flags to '%s'", mpt.dst.c_str());
 		return false;


### PR DESCRIPTION
Fixes #125.

## Summary

`--bindmount_ro` / `-R` uses `MS_REC` while creating the bind, but the final `MS_REMOUNT | MS_BIND | MS_RDONLY` operation only changes the top mount. A writable nested mount such as `/dev/shm` therefore remains writable inside an otherwise read-only recursive bind.

- Apply `MOUNT_ATTR_RDONLY` with `mount_setattr(2)` and `AT_RECURSIVE` before the existing top-level remount.
- Use the same helper for the legacy and new mount backends.
- Keep the existing ordered per-mount remount pass, so a later explicit writable child bind still overrides the recursive parent policy.
- Fail sandbox setup when final mount attributes cannot be enforced instead of continuing with a weaker mount policy.

On kernels without `mount_setattr(2)` support, recursive read-only bind setup now fails closed rather than silently exposing writable nested mounts.

## Verification

- Confirmed the regression on the unmodified image with both `--experimental_mnt=old` and `--experimental_mnt=new`: `-R /dev` still allowed creating a file in `/dev/shm`.
- Confirmed both patched backends reject the nested write with `Read-only file system`.
- Confirmed a later `-B /dev/shm` remains writable with both backends.
- Built with `make -j2` and the project Dockerfile.