### PR TITLE
cgroup: clean up swap-only memory cgroups

### DIFF
--- a/cgroup.cc
+++ b/cgroup.cc
@@ -37,6 +37,18 @@
 
 namespace cgroup {
 
+static size_t getMemSwMax(nsj_t* nsj) {
+	size_t memsw_max = nsj->njc.cgroup_mem_memsw_max();
+	if (nsj->njc.cgroup_mem_swap_max() >= (ssize_t)0) {
+		memsw_max = nsj->njc.cgroup_mem_swap_max() + nsj->njc.cgroup_mem_max();
+	}
+	return memsw_max;
+}
+
+static bool needMemoryCgroup(nsj_t* nsj) {
+	return nsj->njc.cgroup_mem_max() != (size_t)0 || getMemSwMax(nsj) != (size_t)0;
+}
+
 static bool createCgroup(const std::string& cgroup_path, pid_t pid) {
 	LOG_D("Create %s for pid=%d", QC(cgroup_path), (int)pid);
 	if (mkdir(cgroup_path.c_str(), 0700) == -1 && errno != EEXIST) {
@@ -65,10 +77,7 @@ static bool addPidToTaskList(const std::string& cgroup_path, pid_t pid) {
 }
 
 static bool initNsFromParentMem(nsj_t* nsj, pid_t pid) {
-	size_t memsw_max = nsj->njc.cgroup_mem_memsw_max();
-	if (nsj->njc.cgroup_mem_swap_max() >= (ssize_t)0) {
-		memsw_max = nsj->njc.cgroup_mem_swap_max() + nsj->njc.cgroup_mem_max();
-	}
+	size_t memsw_max = getMemSwMax(nsj);
 
 	if (nsj->njc.cgroup_mem_max() == (size_t)0 && memsw_max == (size_t)0) {
 		return true;
@@ -174,8 +183,7 @@ static void removeCgroup(const std::string& cgroup_path) {
 }
 
 void finishFromParent(nsj_t* nsj, pid_t pid) {
-	if (nsj->njc.cgroup_mem_max() != (size_t)0 ||
-	    nsj->njc.cgroup_mem_memsw_max() != (size_t)0) {
+	if (needMemoryCgroup(nsj)) {
 		std::string mem_cgroup_path = nsj->njc.cgroup_mem_mount() + '/' +
 					      nsj->njc.cgroup_mem_parent() + "/NSJAIL." +
 					      std::to_string(pid);

--- a/cgroup2.cc
+++ b/cgroup2.cc
@@ -211,7 +211,7 @@ static bool initNsFromParentMem(nsj_t* nsj, pid_t pid) {
 		swap_max = nsj->njc.cgroup_mem_memsw_max() - nsj->njc.cgroup_mem_max();
 	}
 
-	if (nsj->njc.cgroup_mem_max() == (size_t)0 && swap_max < (ssize_t)0) {
+	if (!needMemoryController(nsj)) {
 		return true;
 	}
 
@@ -268,8 +268,7 @@ bool initNsFromParent(nsj_t* nsj, pid_t pid) {
 }
 
 void finishFromParent(nsj_t* nsj, pid_t pid) {
-	if (nsj->njc.cgroup_mem_max() != (size_t)0 || nsj->njc.cgroup_pids_max() != 0U ||
-	    nsj->njc.cgroup_cpu_ms_per_sec() != 0U) {
+	if (needMemoryController(nsj) || needPidsController(nsj) || needCpuController(nsj)) {
 		removeCgroup(getCgroupPath(nsj, pid));
 	}
 }


### PR DESCRIPTION
## Summary

Keep cgroup memory setup and teardown predicates aligned so swap-only limits do not leave persistent cgroups behind.

- Reuse the effective cgroup-v1 memory+swap calculation for both setup and cleanup.
- Reuse the cgroup-v2 controller predicates for both setup and cleanup.
- Preserve existing behavior for memory, PID, and CPU limits.

## Impact

With cgroup v2, `--cgroup_mem_swap_max 0` creates a per-process `NSJAIL.<pid>` cgroup, but `finishFromParent()` previously checked only `cgroup_mem_max`, `cgroup_pids_max`, and `cgroup_cpu_ms_per_sec`. As a result, every completed process left an empty cgroup on the host.

This is especially visible in `LISTEN` mode: 25 completed TCP connections against an unmodified build left 25 `NSJAIL.<pid>` directories. Connection limits only bound concurrent children, so they do not bound this cumulative leak. A long-running listener can eventually consume cgroup descendants and kernel memory.

Cgroup v1 had the same predicate mismatch when a positive swap-only limit was configured.

## Verification

Built both current `master` and this branch with the project Dockerfile, then ran each image privileged with the host cgroup-v2 mount.

Unmodified `master`, after 25 completed listener connections:

```text
leaked_cgroups=25
/sys/fs/cgroup/NSJAIL.10
/sys/fs/cgroup/NSJAIL.11
/sys/fs/cgroup/NSJAIL.12
...
```

This branch, after the same 25 connections:

```text
remaining_cgroups=0
```

Focused one-shot checks also leave zero cgroups for each configuration:

```text
swap_only_zero_remaining=0
swap_only_positive_remaining=0
memory_only_remaining=0
memory_memsw_remaining=0
pids_only_remaining=0
cpu_only_remaining=0
```

Additional checks:

- `docker build -t nsjail-research:cgroup-fix .`
- `git diff --check`
