### PR TITLE
  nstun: validate TCP acknowledgments before processing payload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,8 +147,19 @@ OLD_EF := --experimental_mnt=old
 NEW_EF := --experimental_mnt=new
 UID := $(shell id -u)
 
-.PHONY: test
-test: $(BIN)
+.PHONY: test tcp_state_test tcp_process_test
+tcp_state_test:
+	$(CXX) -std=c++20 -Wall -Wextra -Werror -Wno-unused-parameter \
+		-I. tests/tcp_state_test.cc -o /tmp/nsjail_tcp_state_test
+	/tmp/nsjail_tcp_state_test
+
+tcp_process_test:
+	$(CXX) -std=c++20 -Wall -Wextra -Werror -Wno-unused -Wno-unused-parameter \
+		-Wno-c99-designator -ffunction-sections -fdata-sections -I. \
+		tests/tcp_process_test.cc -Wl,--gc-sections -o /tmp/nsjail_tcp_process_test
+	/tmp/nsjail_tcp_process_test
+
+test: $(BIN) tcp_state_test tcp_process_test
 	# --- Basic sanity tests ---
 	$(call run_test, ./nsjail -q -Mo --chroot / --user 99999 --group 99999 -- /bin/true, 0)
 	$(call run_test, ./nsjail -q -Mo --chroot / --user 99999 --group 99999 -- /bin/false, 1)

--- a/nstun/core.h
+++ b/nstun/core.h
@@ -64,7 +64,10 @@ public:
 
 	virtual ~Flow() = default;
 	virtual void handle_host_event(Context* ctx, int fd, uint32_t events) = 0;
-	virtual void periodic_check(Context* ctx, time_t now) {}
+	/* Returns true if the check destroyed this flow. */
+	virtual bool periodic_check(Context* ctx, time_t now) {
+		return false;
+	}
 	virtual bool is_stale(time_t now) const = 0;
 	virtual void destroy(Context* ctx) = 0;
 };

--- a/nstun/nstun.cc
+++ b/nstun/nstun.cc
@@ -44,10 +44,15 @@ static void garbage_collect(Context* ctx) {
 	time_t now = time(NULL);
 
 	auto do_gc = [&](auto& map) {
+		std::vector<Flow*> active_flows;
 		std::vector<Flow*> stale_flows;
 		for (auto const& pair : map) {
-			Flow* flow = pair.second.get();
-			flow->periodic_check(ctx, now);
+			active_flows.push_back(pair.second.get());
+		}
+		for (Flow* flow : active_flows) {
+			if (flow->periodic_check(ctx, now)) {
+				continue;
+			}
 			if (flow->is_stale(now)) {
 				stale_flows.push_back(flow);
 			}

--- a/nstun/tcp.cc
+++ b/nstun/tcp.cc
@@ -227,6 +227,15 @@ static inline void tcp_send_packet(
 	}
 }
 
+/* RFC 793 SYN-SENT processing: an unacceptable ACK elicits a reset whose
+ * sequence number is copied from SEG.ACK. The pending flow remains alive. */
+static void tcp_send_reset_for_unacceptable_ack(Context* ctx, TcpFlow* flow, uint32_t ack) {
+	uint32_t saved_seq = flow->seq_to_guest;
+	flow->seq_to_guest = ack;
+	tcp_send_packet(ctx, flow, NSTUN_TCP_FLAG_RST);
+	flow->seq_to_guest = saved_seq;
+}
+
 static void tcp_rst_and_destroy(Context* ctx, TcpFlow* flow) {
 	tcp_send_packet(ctx, flow, NSTUN_TCP_FLAG_RST | NSTUN_TCP_FLAG_ACK);
 	tcp_destroy_flow(ctx, flow);
@@ -246,9 +255,9 @@ void tcp_destroy_flow(Context* ctx, TcpFlow* flow) {
 	}
 }
 
-void push_to_guest(Context* ctx, TcpFlow* flow) {
+bool push_to_guest(Context* ctx, TcpFlow* flow) {
 	if (flow->state != TcpState::ESTABLISHED && flow->state != TcpState::CLOSE_WAIT) {
-		return;
+		return false;
 	}
 
 	/* Max TCP payload per TUN frame: MTU minus IP and TCP headers */
@@ -256,14 +265,23 @@ void push_to_guest(Context* ctx, TcpFlow* flow) {
 	    NSTUN_MTU - (flow->is_ipv6 ? sizeof(ip6_hdr) : sizeof(ip4_hdr)) - sizeof(tcp_hdr);
 
 	for (;;) {
-		int32_t in_flight = flow->seq_to_guest - flow->ack_from_guest;
-		int32_t available = flow->tx_buffer.size() - flow->tx_acked_offset;
-
-		if (in_flight < 0) {
-			/* Guest acked future data? Reset flight */
-			flow->seq_to_guest = flow->ack_from_guest;
-			in_flight = 0;
+		if (flow->tx_acked_offset > flow->tx_buffer.size()) {
+			LOG_E("Invalid TCP transmit-buffer offset (%zu > %zu)",
+			    flow->tx_acked_offset, flow->tx_buffer.size());
+			tcp_rst_and_destroy(ctx, flow);
+			return true;
 		}
+
+		if (tcp_seq_before(flow->seq_to_guest, flow->ack_from_guest)) {
+			LOG_E("Invalid TCP send window: SND.NXT is before SND.UNA");
+			tcp_rst_and_destroy(ctx, flow);
+			return true;
+		}
+
+		size_t in_flight =
+		    static_cast<uint32_t>(flow->seq_to_guest - flow->ack_from_guest);
+		size_t available = flow->tx_buffer.size() - flow->tx_acked_offset;
+
 		if (in_flight >= available) {
 			if (flow->host_eof && available == 0) {
 				if (!flow->fin_sent) {
@@ -274,7 +292,7 @@ void push_to_guest(Context* ctx, TcpFlow* flow) {
 					flow->fin_sent = true;
 				}
 			}
-			return; /* Everything is in flight */
+			return false; /* Everything is in flight */
 		}
 
 		size_t to_send = available - in_flight;
@@ -282,7 +300,7 @@ void push_to_guest(Context* ctx, TcpFlow* flow) {
 
 		const uint8_t* data = flow->tx_buffer.data() + flow->tx_acked_offset + in_flight;
 		uint8_t flags = NSTUN_TCP_FLAG_ACK;
-		if (to_send >= (size_t)(available - in_flight)) {
+		if (to_send >= available - in_flight) {
 			flags |= NSTUN_TCP_FLAG_PSH;
 		}
 
@@ -487,7 +505,9 @@ static void handle_http_connect_wait_host(Context* ctx, TcpFlow* flow, int fd) {
 	flow->seq_to_guest++;
 
 	if (!flow->tx_buffer.empty()) {
-		push_to_guest(ctx, flow);
+		if (push_to_guest(ctx, flow)) {
+			return;
+		}
 	}
 }
 
@@ -514,7 +534,9 @@ static void handle_data_transfer_host(Context* ctx, TcpFlow* flow, int fd) {
 	}
 
 	if (flow->state != TcpState::SYN_SENT) {
-		push_to_guest(ctx, flow);
+		if (push_to_guest(ctx, flow)) {
+			return;
+		}
 	}
 
 	if (flow->tx_buffer.size() - flow->tx_acked_offset > TCP_TX_BUFFER_BACKPRESSURE) {
@@ -563,27 +585,53 @@ static void tcp_process_data(Context* ctx, TcpFlow* flow, const tcp_hdr* tcp,
 	uint32_t seq = ntohl(tcp->seq);
 	uint32_t ack = ntohl(tcp->ack_seq);
 
-	if (flow->inbound && flow->state == TcpState::SYN_SENT &&
-	    (tcp->flags & NSTUN_TCP_FLAG_SYN) && (tcp->flags & NSTUN_TCP_FLAG_ACK)) {
-		flow->state = TcpState::ESTABLISHED;
-		flow->ack_from_guest = ack;
-		flow->seq_from_guest = seq + 1;
-		flow->ack_to_guest = flow->seq_from_guest;
-		flow->syn_acked = true;
-
-		tcp_send_packet(ctx, flow, NSTUN_TCP_FLAG_ACK);
-
-		if (!flow->tx_buffer.empty()) {
-			push_to_guest(ctx, flow);
+	if (flow->state == TcpState::SYN_SENT) {
+		if (tcp->flags & NSTUN_TCP_FLAG_ACK) {
+			TcpAckDisposition disposition =
+			    tcp_classify_ack(flow->ack_from_guest, flow->seq_to_guest, ack);
+			if (disposition != TcpAckDisposition::ADVANCING) {
+				LOG_D("Dropping unacceptable ACK in SYN-SENT");
+				if (!(tcp->flags & NSTUN_TCP_FLAG_RST)) {
+					tcp_send_reset_for_unacceptable_ack(ctx, flow, ack);
+				}
+				return;
+			}
 		}
 
-		if (flow->epoll_in_disabled) {
-			struct epoll_event ev = {
-			    .events = EPOLLIN | EPOLLERR | EPOLLHUP |
-				      (flow->epoll_out_registered ? (uint32_t)EPOLLOUT : 0),
-			    .data = {.fd = flow->host_fd}};
-			epoll_ctl(ctx->epoll_fd, EPOLL_CTL_MOD, flow->host_fd, &ev);
-			flow->epoll_in_disabled = false;
+		if (tcp->flags & NSTUN_TCP_FLAG_RST) {
+			LOG_D("Received acceptable RST in SYN-SENT");
+			tcp_destroy_flow(ctx, flow);
+			return;
+		}
+
+		if (flow->inbound && (tcp->flags & NSTUN_TCP_FLAG_SYN) &&
+		    (tcp->flags & NSTUN_TCP_FLAG_ACK)) {
+			if (tcp_apply_ack(flow, ack) != TcpAckUpdate::ADVANCED) {
+				LOG_W("Failed to apply acceptable SYN-SENT ACK");
+				tcp_rst_and_destroy(ctx, flow);
+				return;
+			}
+
+			flow->state = TcpState::ESTABLISHED;
+			flow->seq_from_guest = seq + 1;
+			flow->ack_to_guest = flow->seq_from_guest;
+
+			tcp_send_packet(ctx, flow, NSTUN_TCP_FLAG_ACK);
+
+			if (!flow->tx_buffer.empty()) {
+				if (push_to_guest(ctx, flow)) {
+					return;
+				}
+			}
+
+			if (flow->epoll_in_disabled) {
+				struct epoll_event ev = {
+				    .events = EPOLLIN | EPOLLERR | EPOLLHUP |
+					      (flow->epoll_out_registered ? (uint32_t)EPOLLOUT : 0),
+				    .data = {.fd = flow->host_fd}};
+				epoll_ctl(ctx->epoll_fd, EPOLL_CTL_MOD, flow->host_fd, &ev);
+				flow->epoll_in_disabled = false;
+			}
 		}
 		return;
 	}
@@ -595,14 +643,58 @@ static void tcp_process_data(Context* ctx, TcpFlow* flow, const tcp_hdr* tcp,
 	}
 
 	if (flow->state == TcpState::ESTABLISHED || flow->state == TcpState::FIN_WAIT_1 ||
-	    flow->state == TcpState::FIN_WAIT_2 || flow->state == TcpState::SYN_SENT ||
-	    flow->state == TcpState::CLOSE_WAIT) {
+	    flow->state == TcpState::FIN_WAIT_2 || flow->state == TcpState::CLOSE_WAIT) {
 		const uint8_t* data = payload.data() + doff;
 		size_t data_len = payload.size() - doff;
 
 		/* Defense-in-depth: cap to MTU to prevent int32_t overflow in seq arithmetic */
 		if (data_len > NSTUN_MTU) {
 			return;
+		}
+
+		/* RFC 793 checks SEG.ACK before processing segment text. */
+		if (!(tcp->flags & NSTUN_TCP_FLAG_ACK)) {
+			return;
+		}
+
+		bool duplicate_ack = ack == flow->ack_from_guest;
+		TcpAckUpdate ack_update = tcp_apply_ack(flow, ack);
+		if (!tcp_ack_allows_payload(ack_update)) {
+			if (ack_update == TcpAckUpdate::FUTURE) {
+				LOG_D("Dropping TCP segment with ACK beyond SND.NXT");
+				tcp_send_packet(ctx, flow, NSTUN_TCP_FLAG_ACK);
+			} else {
+				LOG_W("TCP ACK exceeds buffered data");
+				tcp_rst_and_destroy(ctx, flow);
+			}
+			return;
+		}
+		if (ack_update == TcpAckUpdate::ADVANCED) {
+			if (flow->epoll_in_disabled && !flow->host_eof &&
+			    (flow->tx_buffer.size() - flow->tx_acked_offset <
+				TCP_TX_BUFFER_RESUME)) {
+				struct epoll_event ev = {
+				    .events = EPOLLIN | EPOLLERR | EPOLLHUP |
+					      (flow->epoll_out_registered ? (uint32_t)EPOLLOUT : 0),
+				    .data = {.fd = flow->host_fd}};
+				epoll_ctl(ctx->epoll_fd, EPOLL_CTL_MOD, flow->host_fd, &ev);
+				flow->epoll_in_disabled = false;
+			}
+			if (push_to_guest(ctx, flow)) {
+				return;
+			}
+		} else if (duplicate_ack && data_len == 0 &&
+			   !(tcp->flags & (NSTUN_TCP_FLAG_FIN | NSTUN_TCP_FLAG_SYN |
+					      NSTUN_TCP_FLAG_RST))) {
+			/* Duplicate ACK -> Fast Retransmit */
+			flow->seq_to_guest = flow->ack_from_guest;
+			if (push_to_guest(ctx, flow)) {
+				return;
+			}
+		}
+
+		if (flow->state == TcpState::FIN_WAIT_1 && ack == flow->seq_to_guest) {
+			flow->state = TcpState::FIN_WAIT_2;
 		}
 
 		if (data_len > 0) {
@@ -631,82 +723,9 @@ static void tcp_process_data(Context* ctx, TcpFlow* flow, const tcp_hdr* tcp,
 						return; /* Flow was destroyed */
 					}
 				}
-			} else if (diff > 0) {
-				tcp_send_packet(ctx, flow, NSTUN_TCP_FLAG_ACK);
 			} else {
 				tcp_send_packet(ctx, flow, NSTUN_TCP_FLAG_ACK);
 			}
-		}
-
-		/* Process ACKs from guest */
-		if (tcp->flags & NSTUN_TCP_FLAG_ACK) {
-			if (flow->state == TcpState::SYN_SENT) {
-				flow->state = TcpState::ESTABLISHED;
-				flow->ack_from_guest = ack;
-				flow->syn_acked = true;
-			} else {
-				int32_t acked_bytes = ack - flow->ack_from_guest;
-				if (acked_bytes > 0) {
-					flow->ack_from_guest = ack;
-					if (!flow->syn_acked) {
-						flow->syn_acked = true;
-						acked_bytes--;
-					}
-					if (flow->fin_sent && !flow->fin_acked &&
-					    ack == flow->seq_to_guest) {
-						flow->fin_acked = true;
-						acked_bytes--;
-					}
-					/* acked_bytes is now reliably >= 0 after the
-					 * SYN/FIN decrements above */
-					size_t advance =
-					    (acked_bytes > 0) ? (size_t)acked_bytes : 0;
-					flow->tx_acked_offset += advance;
-
-					size_t erase_len = flow->tx_acked_offset;
-					if (erase_len > flow->tx_buffer.size()) {
-						erase_len = flow->tx_buffer.size();
-					}
-
-					if (erase_len > 65536 ||
-					    erase_len == flow->tx_buffer.size()) {
-						flow->tx_buffer.erase(flow->tx_buffer.begin(),
-						    flow->tx_buffer.begin() + erase_len);
-						flow->tx_acked_offset -= erase_len;
-					}
-
-					if (flow->epoll_in_disabled && !flow->host_eof &&
-					    (flow->tx_buffer.size() - flow->tx_acked_offset <
-						TCP_TX_BUFFER_RESUME)) {
-						struct epoll_event ev = {
-						    .events = EPOLLIN | EPOLLERR | EPOLLHUP |
-							      (flow->epoll_out_registered
-								      ? (uint32_t)EPOLLOUT
-								      : 0),
-						    .data = {.fd = flow->host_fd}};
-						epoll_ctl(ctx->epoll_fd, EPOLL_CTL_MOD,
-						    flow->host_fd, &ev);
-						flow->epoll_in_disabled = false;
-					}
-
-					push_to_guest(ctx, flow);
-				} else if (acked_bytes == 0 && data_len == 0 &&
-					   !(tcp->flags & (NSTUN_TCP_FLAG_FIN | NSTUN_TCP_FLAG_SYN |
-							      NSTUN_TCP_FLAG_RST))) {
-					/* Duplicate ACK -> Fast Retransmit */
-					flow->seq_to_guest = flow->ack_from_guest;
-					push_to_guest(ctx, flow);
-				}
-			}
-
-			if (flow->state == TcpState::FIN_WAIT_1 && ack == flow->seq_to_guest) {
-				flow->state = TcpState::FIN_WAIT_2;
-			}
-		} else if (data_len == 0 &&
-			   !(tcp->flags &
-			       (NSTUN_TCP_FLAG_FIN | NSTUN_TCP_FLAG_SYN | NSTUN_TCP_FLAG_RST))) {
-			flow->seq_to_guest = flow->ack_from_guest;
-			push_to_guest(ctx, flow);
 		}
 
 		if (tcp->flags & NSTUN_TCP_FLAG_FIN) {
@@ -727,7 +746,7 @@ static void tcp_process_data(Context* ctx, TcpFlow* flow, const tcp_hdr* tcp,
 				flow->state = TcpState::TIME_WAIT;
 			}
 
-			push_to_guest(ctx, flow);
+			(void)push_to_guest(ctx, flow);
 			return;
 		}
 	}
@@ -970,7 +989,7 @@ void handle_host_tcp_data_eof(Context* ctx, TcpFlow* flow, int fd) {
 			flow->epoll_in_disabled = true;
 		}
 	}
-	push_to_guest(ctx, flow);
+	(void)push_to_guest(ctx, flow);
 }
 
 void handle_host_tcp(Context* ctx, TcpFlow* flow, uint32_t events) {
@@ -1024,8 +1043,7 @@ void handle_host_tcp(Context* ctx, TcpFlow* flow, uint32_t events) {
 			/* Treat HUP as EOF from host */
 			flow->host_eof = true;
 			flow->epoll_in_disabled = true;
-			push_to_guest(ctx, flow);
-			if (ctx->flows_by_fd.find(fd) == ctx->flows_by_fd.end()) {
+			if (push_to_guest(ctx, flow)) {
 				return;
 			}
 		}
@@ -1311,13 +1329,17 @@ void TcpFlow::handle_host_event(Context* ctx, int fd, uint32_t events) {
 	}
 }
 
-void TcpFlow::periodic_check(Context* ctx, time_t now) {
-	if (this->seq_to_guest > this->ack_from_guest && (now - this->last_active >= 2)) {
+bool TcpFlow::periodic_check(Context* ctx, time_t now) {
+	if (tcp_has_outstanding_sequence(this->ack_from_guest, this->seq_to_guest) &&
+	    (now - this->last_active >= 2)) {
 		LOG_D("TCP RTO triggered for flow (fd=%d)", this->host_fd);
 		this->seq_to_guest = this->ack_from_guest;
-		push_to_guest(ctx, this);
+		if (push_to_guest(ctx, this)) {
+			return true;
+		}
 		this->last_active = now;
 	}
+	return false;
 }
 
 bool TcpFlow::is_stale(time_t now) const {

--- a/nstun/tcp.h
+++ b/nstun/tcp.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "core.h"
+#include "tcp_seq.h"
 
 namespace nstun {
 
@@ -64,17 +65,73 @@ struct TcpFlow : public Flow {
 	}
 
 	void handle_host_event(Context* ctx, int fd, uint32_t events) override;
-	void periodic_check(Context* ctx, time_t now) override;
+	bool periodic_check(Context* ctx, time_t now) override;
 	bool is_stale(time_t now) const override;
 	void destroy(Context* ctx) override;
 };
+
+enum class TcpAckUpdate {
+	OLD_OR_DUPLICATE,
+	ADVANCED,
+	FUTURE,
+	INVALID_BUFFER,
+};
+
+inline bool tcp_ack_allows_payload(TcpAckUpdate update) {
+	return update == TcpAckUpdate::OLD_OR_DUPLICATE || update == TcpAckUpdate::ADVANCED;
+}
+
+/* Apply an acceptable ACK to the send-side state. Future and internally
+ * inconsistent ACKs leave the flow unchanged. */
+template <typename Flow>
+inline TcpAckUpdate tcp_apply_ack(Flow* flow, uint32_t ack) {
+	TcpAckDisposition disposition =
+	    tcp_classify_ack(flow->ack_from_guest, flow->seq_to_guest, ack);
+	if (disposition == TcpAckDisposition::FUTURE) {
+		return TcpAckUpdate::FUTURE;
+	}
+	if (disposition != TcpAckDisposition::ADVANCING) {
+		return TcpAckUpdate::OLD_OR_DUPLICATE;
+	}
+
+	size_t sequence_advance = static_cast<uint32_t>(ack - flow->ack_from_guest);
+	bool acknowledges_syn = !flow->syn_acked;
+	bool acknowledges_fin =
+	    flow->fin_sent && !flow->fin_acked && ack == flow->seq_to_guest;
+	size_t control_advance =
+	    static_cast<size_t>(acknowledges_syn) + static_cast<size_t>(acknowledges_fin);
+	if (sequence_advance < control_advance) {
+		return TcpAckUpdate::INVALID_BUFFER;
+	}
+	size_t data_advance = sequence_advance - control_advance;
+
+	if (flow->tx_acked_offset > flow->tx_buffer.size() ||
+	    data_advance > flow->tx_buffer.size() - flow->tx_acked_offset) {
+		return TcpAckUpdate::INVALID_BUFFER;
+	}
+
+	flow->ack_from_guest = ack;
+	flow->syn_acked = flow->syn_acked || acknowledges_syn;
+	flow->fin_acked = flow->fin_acked || acknowledges_fin;
+	flow->tx_acked_offset += data_advance;
+
+	size_t erase_len = flow->tx_acked_offset;
+	if (erase_len > 65536 || erase_len == flow->tx_buffer.size()) {
+		flow->tx_buffer.erase(
+		    flow->tx_buffer.begin(), flow->tx_buffer.begin() + erase_len);
+		flow->tx_acked_offset -= erase_len;
+	}
+
+	return TcpAckUpdate::ADVANCED;
+}
 
 void tcp_send_packet4(
     Context* ctx, TcpFlow* flow, uint8_t flags, const uint8_t* data = nullptr, size_t len = 0);
 void tcp_send_packet6(
     Context* ctx, TcpFlow* flow, uint8_t flags, const uint8_t* data = nullptr, size_t len = 0);
 void tcp_destroy_flow(Context* ctx, TcpFlow* flow);
-void push_to_guest(Context* ctx, TcpFlow* flow);
+/* Returns true if the flow was destroyed. */
+bool push_to_guest(Context* ctx, TcpFlow* flow);
 
 void handle_tcp4(Context* ctx, const ip4_hdr* ip, std::span<const uint8_t> payload);
 void handle_tcp6(Context* ctx, const ip6_hdr* ip, std::span<const uint8_t> payload);

--- a/nstun/tcp_seq.h
+++ b/nstun/tcp_seq.h
@@ -1,0 +1,49 @@
+#ifndef NSTUN_TCP_SEQ_H_
+#define NSTUN_TCP_SEQ_H_
+
+#include <stdint.h>
+
+namespace nstun {
+
+/* TCP sequence numbers use modulo-2^32 serial arithmetic. */
+inline bool tcp_seq_after(uint32_t lhs, uint32_t rhs) {
+	return static_cast<int32_t>(lhs - rhs) > 0;
+}
+
+inline bool tcp_seq_before(uint32_t lhs, uint32_t rhs) {
+	return tcp_seq_after(rhs, lhs);
+}
+
+inline bool tcp_has_outstanding_sequence(uint32_t ack_from_guest, uint32_t seq_to_guest) {
+	return tcp_seq_after(seq_to_guest, ack_from_guest);
+}
+
+enum class TcpAckDisposition {
+	OLD,
+	DUPLICATE,
+	ADVANCING,
+	FUTURE,
+};
+
+inline TcpAckDisposition tcp_classify_ack(
+    uint32_t ack_from_guest, uint32_t seq_to_guest, uint32_t ack) {
+	if (ack == ack_from_guest) {
+		return TcpAckDisposition::DUPLICATE;
+	}
+	if (tcp_seq_after(ack, seq_to_guest)) {
+		return TcpAckDisposition::FUTURE;
+	}
+	if (tcp_seq_after(ack, ack_from_guest)) {
+		return TcpAckDisposition::ADVANCING;
+	}
+	return TcpAckDisposition::OLD;
+}
+
+inline bool tcp_ack_in_send_window(uint32_t ack_from_guest, uint32_t seq_to_guest, uint32_t ack) {
+	return tcp_classify_ack(ack_from_guest, seq_to_guest, ack) ==
+	       TcpAckDisposition::ADVANCING;
+}
+
+} /* namespace nstun */
+
+#endif /* NSTUN_TCP_SEQ_H_ */

--- a/tests/tcp_process_test.cc
+++ b/tests/tcp_process_test.cc
@@ -1,0 +1,249 @@
+#include <assert.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <memory>
+#include <vector>
+
+#include "nstun/tcp.cc"
+
+namespace {
+struct SentPacket {
+	uint8_t flags;
+	uint32_t seq;
+	uint32_t ack;
+	size_t payload_len;
+};
+
+std::vector<SentPacket> sent_packets;
+
+nstun::TcpFlow* add_ipv4_flow(nstun::Context* ctx, const nstun::FlowKey4& key) {
+	auto owned = std::make_unique<nstun::TcpFlow>();
+	nstun::TcpFlow* flow = owned.get();
+	flow->is_ipv6 = false;
+	flow->host_fd = -1;
+	flow->key4 = key;
+	ctx->ipv4_tcp_flows_by_key[key] = std::move(owned);
+	return flow;
+}
+
+std::vector<uint8_t> make_tcp_segment(
+    uint32_t seq, uint32_t ack, uint8_t flags, std::span<const uint8_t> data = {}) {
+	std::vector<uint8_t> segment(sizeof(nstun::tcp_hdr) + data.size(), 0);
+	auto* tcp = reinterpret_cast<nstun::tcp_hdr*>(segment.data());
+	tcp->seq = htonl(seq);
+	tcp->ack_seq = htonl(ack);
+	tcp->flags = flags;
+	if (!data.empty()) {
+		memcpy(segment.data() + sizeof(nstun::tcp_hdr), data.data(), data.size());
+	}
+	return segment;
+}
+
+void process_segment(nstun::Context* ctx, nstun::TcpFlow* flow, std::vector<uint8_t>* segment) {
+	auto* tcp = reinterpret_cast<nstun::tcp_hdr*>(segment->data());
+	nstun::tcp_process_data(
+	    ctx, flow, tcp, std::span<const uint8_t>(*segment), sizeof(nstun::tcp_hdr));
+}
+} /* namespace */
+
+namespace logs {
+llevel_t getLogLevel() {
+	return FATAL;
+}
+
+void logMsg(llevel_t, const char*, int, bool, const char*, ...) {}
+} /* namespace logs */
+
+namespace util {
+uint64_t rnd64() {
+	return 0x1000U;
+}
+} /* namespace util */
+
+namespace nstun {
+Context::~Context() = default;
+
+void UdpFlow::handle_host_event(Context*, int, uint32_t) {}
+bool UdpFlow::is_stale(time_t) const {
+	return false;
+}
+void UdpFlow::destroy(Context*) {}
+
+void IcmpFlow::handle_host_event(Context*, int, uint32_t) {}
+bool IcmpFlow::is_stale(time_t) const {
+	return false;
+}
+void IcmpFlow::destroy(Context*) {}
+
+RuleResult evaluate_rules4(Context*, nstun_direction_t, nstun_proto_t, uint32_t, uint32_t,
+    uint16_t, uint16_t) {
+	return {};
+}
+
+RuleResult evaluate_rules6(Context*, nstun_direction_t, nstun_proto_t, const uint8_t*,
+    const uint8_t*, uint16_t, uint16_t) {
+	return {};
+}
+
+bool send_to_guest_v(
+    Context*, const void* header, size_t header_len, const void*, size_t payload_len) {
+	assert(header_len >= sizeof(ip4_hdr) + sizeof(tcp_hdr));
+	const auto* bytes = reinterpret_cast<const uint8_t*>(header);
+	assert((bytes[0] >> 4) == 4);
+	const auto* tcp = reinterpret_cast<const tcp_hdr*>(bytes + sizeof(ip4_hdr));
+	sent_packets.push_back({
+	    .flags = tcp->flags,
+	    .seq = ntohl(tcp->seq),
+	    .ack = ntohl(tcp->ack_seq),
+	    .payload_len = payload_len,
+	});
+	return true;
+}
+
+int send_http_connect(int, const uint8_t*, uint16_t, bool) {
+	return 0;
+}
+size_t find_end_of_headers(const std::vector<uint8_t>&) {
+	return 0;
+}
+bool parse_http_connect_reply(const std::vector<uint8_t>&) {
+	return true;
+}
+int send_socks5_greeting(int) {
+	return 0;
+}
+bool parse_socks5_auth_reply(std::span<const uint8_t>) {
+	return true;
+}
+int send_socks5_connect(int, const uint8_t*, uint16_t, bool) {
+	return 0;
+}
+} /* namespace nstun */
+
+namespace {
+
+void test_future_ack_drops_payload_without_mutation() {
+	sent_packets.clear();
+	nstun::Context ctx = {};
+	ctx.epoll_fd = -1;
+	ctx.tap_fd = -1;
+
+	const nstun::FlowKey4 key = {};
+	nstun::TcpFlow* flow = add_ipv4_flow(&ctx, key);
+	flow->state = nstun::TcpState::ESTABLISHED;
+	flow->syn_acked = true;
+	flow->ack_from_guest = 0x1000U;
+	flow->seq_to_guest = 0x1010U;
+	flow->seq_from_guest = 0x2000U;
+	flow->ack_to_guest = 0x2000U;
+	flow->tx_buffer.resize(16, 0x41);
+
+	const std::vector<uint8_t> original_tx_buffer = flow->tx_buffer;
+	const uint8_t data[] = {'A', 'B', 'C'};
+	/* Acceptable receive sequence with an ACK beyond SND.NXT. */
+	std::vector<uint8_t> segment =
+	    make_tcp_segment(0x2000U, 0x40001000U, nstun::NSTUN_TCP_FLAG_ACK, data);
+	process_segment(&ctx, flow, &segment);
+
+	auto it = ctx.ipv4_tcp_flows_by_key.find(key);
+	assert(it != ctx.ipv4_tcp_flows_by_key.end());
+	flow = it->second.get();
+	assert(flow->ack_from_guest == 0x1000U);
+	assert(flow->seq_to_guest == 0x1010U);
+	assert(flow->tx_acked_offset == 0);
+	assert(flow->tx_buffer == original_tx_buffer);
+	assert(flow->rx_buffer.empty());
+	assert(sent_packets.size() == 1);
+	assert(sent_packets[0].flags == nstun::NSTUN_TCP_FLAG_ACK);
+	assert(sent_packets[0].seq == 0x1010U);
+	assert(sent_packets[0].ack == 0x2000U);
+	assert(sent_packets[0].payload_len == 0);
+}
+
+void test_syn_sent_rejects_unacceptable_ack() {
+	sent_packets.clear();
+	nstun::Context ctx = {};
+	const nstun::FlowKey4 key = {};
+	nstun::TcpFlow* flow = add_ipv4_flow(&ctx, key);
+	flow->state = nstun::TcpState::SYN_SENT;
+	flow->inbound = true;
+	flow->syn_acked = false;
+	flow->ack_from_guest = 0x1000U;
+	flow->seq_to_guest = 0x1001U;
+	flow->ack_to_guest = 0x2000U;
+	flow->tx_buffer = {0x41, 0x42};
+	const std::vector<uint8_t> original_tx_buffer = flow->tx_buffer;
+
+	std::vector<uint8_t> segment =
+	    make_tcp_segment(0x2000U, 0x1002U, nstun::NSTUN_TCP_FLAG_ACK);
+	process_segment(&ctx, flow, &segment);
+
+	auto it = ctx.ipv4_tcp_flows_by_key.find(key);
+	assert(it != ctx.ipv4_tcp_flows_by_key.end());
+	flow = it->second.get();
+	assert(flow->state == nstun::TcpState::SYN_SENT);
+	assert(!flow->syn_acked);
+	assert(flow->ack_from_guest == 0x1000U);
+	assert(flow->seq_to_guest == 0x1001U);
+	assert(flow->tx_buffer == original_tx_buffer);
+	assert(sent_packets.size() == 1);
+	assert(sent_packets[0].flags == nstun::NSTUN_TCP_FLAG_RST);
+	assert(sent_packets[0].seq == 0x1002U);
+	assert(sent_packets[0].payload_len == 0);
+}
+
+void test_valid_inbound_syn_ack_establishes_flow() {
+	sent_packets.clear();
+	nstun::Context ctx = {};
+	const nstun::FlowKey4 key = {};
+	nstun::TcpFlow* flow = add_ipv4_flow(&ctx, key);
+	flow->state = nstun::TcpState::SYN_SENT;
+	flow->inbound = true;
+	flow->syn_acked = false;
+	flow->ack_from_guest = 0x1000U;
+	flow->seq_to_guest = 0x1001U;
+
+	std::vector<uint8_t> segment = make_tcp_segment(
+	    0x2000U, 0x1001U, nstun::NSTUN_TCP_FLAG_SYN | nstun::NSTUN_TCP_FLAG_ACK);
+	process_segment(&ctx, flow, &segment);
+
+	auto it = ctx.ipv4_tcp_flows_by_key.find(key);
+	assert(it != ctx.ipv4_tcp_flows_by_key.end());
+	flow = it->second.get();
+	assert(flow->state == nstun::TcpState::ESTABLISHED);
+	assert(flow->syn_acked);
+	assert(flow->ack_from_guest == 0x1001U);
+	assert(flow->seq_to_guest == 0x1001U);
+	assert(flow->seq_from_guest == 0x2001U);
+	assert(flow->ack_to_guest == 0x2001U);
+	assert(sent_packets.size() == 1);
+	assert(sent_packets[0].flags == nstun::NSTUN_TCP_FLAG_ACK);
+	assert(sent_packets[0].seq == 0x1001U);
+	assert(sent_packets[0].ack == 0x2001U);
+	assert(sent_packets[0].payload_len == 0);
+}
+
+void test_push_to_guest_reports_destruction() {
+	sent_packets.clear();
+
+	nstun::Context invalid_ctx = {};
+	const nstun::FlowKey4 key = {};
+	nstun::TcpFlow* invalid_flow = add_ipv4_flow(&invalid_ctx, key);
+	invalid_flow->state = nstun::TcpState::ESTABLISHED;
+	invalid_flow->tx_buffer = {0x42};
+	invalid_flow->tx_acked_offset = 2;
+	assert(nstun::push_to_guest(&invalid_ctx, invalid_flow));
+	assert(invalid_ctx.ipv4_tcp_flows_by_key.empty());
+}
+
+} /* namespace */
+
+int main() {
+	test_future_ack_drops_payload_without_mutation();
+	test_syn_sent_rejects_unacceptable_ack();
+	test_valid_inbound_syn_ack_establishes_flow();
+	test_push_to_guest_reports_destruction();
+	return 0;
+}

--- a/tests/tcp_state_test.cc
+++ b/tests/tcp_state_test.cc
@@ -1,0 +1,145 @@
+#include <assert.h>
+#include <stdint.h>
+
+#include <vector>
+
+#include "nstun/tcp.h"
+
+namespace {
+
+struct SendState {
+	bool syn_acked = true;
+	bool fin_sent = false;
+	bool fin_acked = false;
+	uint32_t seq_to_guest = 0;
+	uint32_t ack_from_guest = 0;
+	std::vector<uint8_t> tx_buffer;
+	size_t tx_acked_offset = 0;
+};
+
+void test_ack_classification() {
+	assert(nstun::tcp_classify_ack(100, 200, 99) == nstun::TcpAckDisposition::OLD);
+	assert(nstun::tcp_classify_ack(100, 200, 100) ==
+	       nstun::TcpAckDisposition::DUPLICATE);
+	assert(nstun::tcp_classify_ack(100, 200, 150) ==
+	       nstun::TcpAckDisposition::ADVANCING);
+	assert(nstun::tcp_classify_ack(100, 200, 201) ==
+	       nstun::TcpAckDisposition::FUTURE);
+}
+
+void test_wraparound_ack_and_retransmission_comparisons() {
+	assert(nstun::tcp_has_outstanding_sequence(0xfffffff0U, 0x20U));
+	assert(!nstun::tcp_has_outstanding_sequence(0x20U, 0xfffffff0U));
+	assert(nstun::tcp_ack_in_send_window(0xfffffff0U, 0x20U, 0x10U));
+	assert(!nstun::tcp_ack_in_send_window(0xfffffff0U, 0x20U, 0x30U));
+}
+
+void test_valid_ack_updates_send_state() {
+	SendState state;
+	state.ack_from_guest = 100;
+	state.seq_to_guest = 116;
+	state.tx_buffer.resize(16, 0x41);
+
+	assert(nstun::tcp_apply_ack(&state, 108) == nstun::TcpAckUpdate::ADVANCED);
+	assert(state.ack_from_guest == 108);
+	assert(state.tx_acked_offset == 8);
+	assert(state.tx_buffer.size() == 16);
+
+	assert(nstun::tcp_apply_ack(&state, 116) == nstun::TcpAckUpdate::ADVANCED);
+	assert(state.ack_from_guest == 116);
+	assert(state.tx_acked_offset == 0);
+	assert(state.tx_buffer.empty());
+}
+
+void test_forged_future_ack_drops_segment_without_mutation() {
+	SendState state;
+	state.ack_from_guest = 0x1000U;
+	state.seq_to_guest = 0x1010U;
+	state.tx_buffer.resize(16, 0x42);
+	state.tx_acked_offset = 3;
+
+	const uint32_t forged_acks[] = {
+	    0x10001000U,
+	    0x20001000U,
+	    0x30001000U,
+	    0x40001000U,
+	    0x50001000U,
+	    0x60001000U,
+	    0x70001000U,
+	};
+	const SendState original = state;
+	bool payload_delivered = false;
+	for (uint32_t forged_ack : forged_acks) {
+		nstun::TcpAckUpdate update = nstun::tcp_apply_ack(&state, forged_ack);
+		assert(update == nstun::TcpAckUpdate::FUTURE);
+		if (nstun::tcp_ack_allows_payload(update)) {
+			payload_delivered = true;
+		}
+		assert(state.ack_from_guest == original.ack_from_guest);
+		assert(state.seq_to_guest == original.seq_to_guest);
+		assert(state.tx_acked_offset == original.tx_acked_offset);
+		assert(state.tx_buffer == original.tx_buffer);
+	}
+	assert(!payload_delivered);
+}
+
+void test_invalid_buffer_state_is_not_partially_updated() {
+	SendState state;
+	state.ack_from_guest = 100;
+	state.seq_to_guest = 108;
+	state.tx_buffer.resize(4, 0x43);
+
+	const SendState original = state;
+	nstun::TcpAckUpdate update = nstun::tcp_apply_ack(&state, 108);
+	assert(update == nstun::TcpAckUpdate::INVALID_BUFFER);
+	assert(!nstun::tcp_ack_allows_payload(update));
+	assert(state.ack_from_guest == original.ack_from_guest);
+	assert(state.syn_acked == original.syn_acked);
+	assert(state.fin_acked == original.fin_acked);
+	assert(state.tx_acked_offset == original.tx_acked_offset);
+	assert(state.tx_buffer == original.tx_buffer);
+}
+
+void test_syn_sent_ack_window() {
+	/* A SYN consumes exactly one sequence number. */
+	assert(nstun::tcp_ack_in_send_window(0xfffffff0U, 0xfffffff1U, 0xfffffff1U));
+	assert(!nstun::tcp_ack_in_send_window(0xfffffff0U, 0xfffffff1U, 0xfffffff0U));
+	assert(!nstun::tcp_ack_in_send_window(0xfffffff0U, 0xfffffff1U, 0xfffffff2U));
+
+	SendState state;
+	state.syn_acked = false;
+	state.ack_from_guest = 0xfffffff0U;
+	state.seq_to_guest = 0xfffffff1U;
+	assert(nstun::tcp_apply_ack(&state, 0xfffffff1U) ==
+	       nstun::TcpAckUpdate::ADVANCED);
+	assert(state.syn_acked);
+	assert(state.ack_from_guest == 0xfffffff1U);
+	assert(state.tx_acked_offset == 0);
+}
+
+void test_fin_ack_accounts_only_for_buffered_data() {
+	SendState state;
+	state.fin_sent = true;
+	state.ack_from_guest = 100;
+	state.seq_to_guest = 105;
+	state.tx_buffer.resize(4, 0x44);
+
+	assert(nstun::tcp_apply_ack(&state, 105) == nstun::TcpAckUpdate::ADVANCED);
+	assert(state.fin_acked);
+	assert(state.ack_from_guest == 105);
+	assert(state.tx_acked_offset == 0);
+	assert(state.tx_buffer.empty());
+}
+
+} /* namespace */
+
+int main() {
+	test_ack_classification();
+	test_wraparound_ack_and_retransmission_comparisons();
+	test_valid_ack_updates_send_state();
+	test_forged_future_ack_drops_segment_without_mutation();
+	test_invalid_buffer_state_is_not_partially_updated();
+	test_syn_sent_ack_window();
+	test_fin_ack_accounts_only_for_buffered_data();
+	return 0;
+}


### PR DESCRIPTION
# nstun: validate TCP acknowledgments before processing payload

## Summary

This change makes nstun validate guest TCP acknowledgments before using them to
mutate send-side state or deliver segment payload.

- Classifies ACKs with wraparound-safe TCP serial-number arithmetic.
- Rejects ACKs beyond `SND.NXT` before processing segment text.
- Applies the same ACK acceptability checks in `SYN-SENT`.
- Accounts for SYN, buffered data, and FIN sequence space before committing a
  cumulative ACK.
- Uses wraparound-safe sequence comparison in the retransmission timer.
- Makes flow destruction from `push_to_guest()` explicit to callers.
- Adds focused helper and production-path regression tests.

## Bug

The synchronized-state receive path previously processed segment payload before
validating `SEG.ACK`. A guest could therefore attach payload to an ACK beyond
`SND.NXT`; the payload could reach the host-facing receive path before the
invalid acknowledgment was reflected in send-side accounting.

The old ACK accounting then calculated an advance directly from the supplied
32-bit ACK and updated `ack_from_guest` and `tx_acked_offset`. An ACK outside the
current send window could consequently move the flow beyond the data actually
sent or buffered.

`SYN-SENT` also accepted acknowledgment state without applying the same send
window invariant. Separately, the retransmission timer compared sequence
numbers with ordinary integer ordering, which is incorrect when the sequence
space wraps at `UINT32_MAX`.

## Fix

The receive path now classifies every ACK relative to `SND.UNA` and `SND.NXT`
before processing payload:

- Old and duplicate ACKs leave send-side state unchanged.
- Advancing ACKs are applied only after their SYN, data, and FIN sequence-space
  consumption is consistent with the transmit buffer.
- Future ACKs leave the flow unchanged, drop any attached payload, and produce
  a corrective ACK.
- Internally inconsistent buffer accounting resets and destroys the flow
  instead of partially committing state.

`SYN-SENT` rejects unacceptable acknowledgments before performing RST or
SYN|ACK processing. An unacceptable ACK without RST produces the reset response
specified for that state, while an acceptable inbound SYN|ACK completes the
transition to `ESTABLISHED`.

The defensive buffer checks mean `push_to_guest()` can synchronously destroy a
flow. Its return value now reports that invalidation, and callers stop using the
flow immediately. Garbage collection snapshots active flow pointers before
running callbacks so callback-driven erasure does not invalidate the map
iteration itself.

## Regression coverage

`tests/tcp_state_test.cc` covers:

- Old, duplicate, advancing, and future ACK classification.
- TCP sequence-number wraparound.
- Partial and complete cumulative ACK accounting.
- Repeated future ACKs leaving send state and buffered data unchanged.
- Rejection of ACK advances inconsistent with the transmit buffer.
- SYN and FIN sequence-space accounting.

`tests/tcp_process_test.cc` exercises the actual TCP processing implementation
with external I/O stubbed. It verifies that:

- A future ACK carrying `ABC` does not change `ack_from_guest`,
  `seq_to_guest`, `tx_acked_offset`, or `tx_buffer`.
- The attached payload is not delivered to the host-facing receive buffer.
- The flow remains owned and exactly one payload-free corrective ACK is sent.
- An unacceptable ACK in `SYN-SENT` preserves the pending flow and emits an RST
  whose sequence number is copied from `SEG.ACK`.
- A valid inbound SYN|ACK transitions the flow to `ESTABLISHED` and emits the
  expected final ACK.
- The destructive `push_to_guest()` path reports destruction without callers
  subsequently accessing the invalidated pointer.

## Verification

Local verification performed:

- `make tcp_state_test`
- `make tcp_process_test`
- Both focused tests with GCC ASan/UBSan
- Both focused tests with Clang
- GCC object compilation of `nstun/tcp.cc`
- GCC object compilation of `nstun/nstun.cc`
- `git diff --check`

The full nsjail binary was not linked locally because this checkout does not
contain the `kafel` submodule and network access was unavailable. The focused
tests and directly affected translation units compile successfully.
