### PR TITLE
Reject invalid integer command-line arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,8 +147,19 @@ OLD_EF := --experimental_mnt=old
 NEW_EF := --experimental_mnt=new
 UID := $(shell id -u)
 
+.PHONY: test-cmdline
+test-cmdline: $(BIN)
+	# --- Command-line integer parsing ---
+	$(call run_test, ./nsjail --time_limit 1.5 --help > /dev/null, 255)
+	$(call run_test, ./nsjail --time_limit=-1 --help > /dev/null, 255)
+	$(call run_test, ./nsjail --max_cpus 4294967296 --help > /dev/null, 255)
+	$(call run_test, ./nsjail --nice_level=2147483648 --help > /dev/null, 255)
+	$(call run_test, ./nsjail --user 1000:1000:1.5 --help > /dev/null, 255)
+	$(call run_test, ./nsjail --rlimit_cpu 1.5 --help > /dev/null, 255)
+	$(call run_test, ./nsjail --time_limit 0x10 --cgroup_mem_swap_max=-1 --user 1000:1000:1 --help > /dev/null, 0)
+
 .PHONY: test
-test: $(BIN)
+test: $(BIN) test-cmdline
 	# --- Basic sanity tests ---
 	$(call run_test, ./nsjail -q -Mo --chroot / --user 99999 --group 99999 -- /bin/true, 0)
 	$(call run_test, ./nsjail -q -Mo --chroot / --user 99999 --group 99999 -- /bin/false, 1)

--- a/cmdline.cc
+++ b/cmdline.cc
@@ -43,9 +43,11 @@
 #include <unistd.h>
 
 #include <cstddef>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "caps.h"
@@ -182,6 +184,33 @@ static const struct custom_option custom_opts[] = {
 
 static const char* logYesNo(bool yes) {
 	return (yes ? "true" : "false");
+}
+
+template <typename T>
+static bool parseUnsignedOption(const char* option, const char* arg, T* value) {
+	static_assert(std::is_integral_v<T> && std::is_unsigned_v<T>);
+
+	uint64_t parsed = 0;
+	if (!util::parseUint64(arg, &parsed) || parsed > std::numeric_limits<T>::max()) {
+		LOG_E("Invalid integer value for --%s: %s", option, QC(arg));
+		return false;
+	}
+	*value = (T)parsed;
+	return true;
+}
+
+template <typename T>
+static bool parseSignedOption(const char* option, const char* arg, T* value) {
+	static_assert(std::is_integral_v<T> && std::is_signed_v<T>);
+
+	int64_t parsed = 0;
+	if (!util::parseInt64(arg, &parsed) || parsed < std::numeric_limits<T>::min() ||
+	    parsed > std::numeric_limits<T>::max()) {
+		LOG_E("Invalid integer value for --%s: %s", option, QC(arg));
+		return false;
+	}
+	*value = (T)parsed;
+	return true;
 }
 
 size_t GetConsoleLength(const std::string& str) {
@@ -342,7 +371,8 @@ nsjail::RLimit parseRLimitType(int res, const char* optarg) {
 	if (strcasecmp(optarg, "inf") == 0) {
 		return nsjail::RLimit::INF;
 	}
-	if (util::isANumber(optarg)) {
+	uint64_t value = 0;
+	if (util::parseUint64(optarg, &value)) {
 		return nsjail::RLimit::VALUE;
 	}
 	LOG_F("RLIMIT %s (%d) needs a numeric value or 'max'/'hard'/'def'/'soft'/'inf' "
@@ -365,15 +395,16 @@ uint64_t parseRLimit(int res, const char* optarg, unsigned long mul) {
 	if (strcasecmp(optarg, "max") == 0 || strcasecmp(optarg, "hard") == 0) {
 		return cur.rlim_max;
 	}
-	if (!util::isANumber(optarg)) {
+	uint64_t val = 0;
+	if (!util::parseUint64(optarg, &val)) {
 		LOG_F("RLIMIT %s (%d) needs a numeric value or 'max'/'hard'/'def'/'soft'/'inf' "
 		      "value (%s provided)",
 		    util::rLimName(res).c_str(), res, QC(optarg));
 	}
-	errno = 0;
-	uint64_t val = strtoull(optarg, NULL, 0);
-	if (val == ULLONG_MAX && errno != 0) {
-		PLOG_F("strtoull('%s', 0)", optarg);
+	if (mul != 0 && val > std::numeric_limits<uint64_t>::max() / mul) {
+		LOG_F("RLIMIT %s (%d) value overflows after applying its unit multiplier (%s "
+		      "provided)",
+		    util::rLimName(res).c_str(), res, QC(optarg));
 	}
 	return val * mul;
 }
@@ -383,6 +414,14 @@ static std::string argFromVec(const std::vector<std::string>& vec, size_t pos) {
 		return "";
 	}
 	return vec[pos];
+}
+
+static bool parseMappingCount(const char* option, const std::string& arg, size_t* count) {
+	if (arg.empty()) {
+		*count = 0;
+		return true;
+	}
+	return parseUnsignedOption(option, arg.c_str(), count);
 }
 
 static bool setupArgv(nsj_t* nsj, int argc, char** argv, int optind) {
@@ -527,29 +566,41 @@ std::unique_ptr<nsj_t> parseArgs(int argc, char* argv[]) {
 		case 'c':
 			nsj->chroot = optarg;
 			break;
-		case 'p':
-			if (!util::isANumber(optarg)) {
-				LOG_E("Couldn't parse TCP port '%s'", optarg);
+		case 'p': {
+			uint32_t value = 0;
+			if (!parseUnsignedOption("port", optarg, &value)) {
 				return nullptr;
 			}
-			nsj->njc.set_port(strtoumax(optarg, NULL, 0));
+			nsj->njc.set_port(value);
 			nsj->njc.set_mode(nsjail::Mode::LISTEN);
-			break;
+		} break;
 		case 0x604:
 			nsj->njc.set_bindhost(optarg);
 			break;
-		case 0x608:
-			nsj->njc.set_max_conns(strtoul(optarg, NULL, 0));
-			break;
-		case 'i':
-			nsj->njc.set_max_conns_per_ip(strtoul(optarg, NULL, 0));
-			break;
+		case 0x608: {
+			uint32_t value = 0;
+			if (!parseUnsignedOption("max_conns", optarg, &value)) {
+				return nullptr;
+			}
+			nsj->njc.set_max_conns(value);
+		} break;
+		case 'i': {
+			uint32_t value = 0;
+			if (!parseUnsignedOption("max_conns_per_ip", optarg, &value)) {
+				return nullptr;
+			}
+			nsj->njc.set_max_conns_per_ip(value);
+		} break;
 		case 'l':
 			logs::logFile(optarg, STDERR_FILENO);
 			break;
-		case 'L':
-			logs::logFile("", std::strtol(optarg, NULL, 0));
-			break;
+		case 'L': {
+			int value = 0;
+			if (!parseSignedOption("log_fd", optarg, &value)) {
+				return nullptr;
+			}
+			logs::logFile("", value);
+		} break;
 		case 'd':
 			nsj->njc.set_daemon(true);
 			break;
@@ -565,9 +616,13 @@ std::unique_ptr<nsj_t> parseArgs(int argc, char* argv[]) {
 		case 'e':
 			nsj->njc.set_keep_env(true);
 			break;
-		case 't':
-			nsj->njc.set_time_limit((uint64_t)strtoull(optarg, NULL, 0));
-			break;
+		case 't': {
+			uint32_t value = 0;
+			if (!parseUnsignedOption("time_limit", optarg, &value)) {
+				return nullptr;
+			}
+			nsj->njc.set_time_limit(value);
+		} break;
 		case 'h': /* help */
 			logs::logFile("", STDOUT_FILENO);
 			cmdlineUsage(argv[0]);
@@ -688,15 +743,23 @@ std::unique_ptr<nsj_t> parseArgs(int argc, char* argv[]) {
 		case 0x0504:
 			nsj->njc.set_skip_setsid(true);
 			break;
-		case 0x0505:
-			nsj->openfds.push_back((int)strtol(optarg, NULL, 0));
-			break;
+		case 0x0505: {
+			int value = 0;
+			if (!parseSignedOption("pass_fd", optarg, &value)) {
+				return nullptr;
+			}
+			nsj->openfds.push_back(value);
+		} break;
 		case 0x0507:
 			nsj->njc.set_disable_no_new_privs(true);
 			break;
-		case 0x0508:
-			nsj->njc.set_max_cpus(strtoul(optarg, NULL, 0));
-			break;
+		case 0x0508: {
+			uint32_t value = 0;
+			if (!parseUnsignedOption("max_cpus", optarg, &value)) {
+				return nullptr;
+			}
+			nsj->njc.set_max_cpus(value);
+		} break;
 		case 0x0509: {
 			int cap = caps::nameToVal(optarg);
 			if (cap == -1) {
@@ -750,7 +813,10 @@ std::unique_ptr<nsj_t> parseArgs(int argc, char* argv[]) {
 			std::string i_id = argFromVec(subopts, 0);
 			std::string o_id = argFromVec(subopts, 1);
 			std::string cnt = argFromVec(subopts, 2);
-			size_t count = strtoul(cnt.c_str(), nullptr, 0);
+			size_t count = 0;
+			if (!parseMappingCount("user", cnt, &count)) {
+				return nullptr;
+			}
 			if (!user::parseId(nsj.get(), i_id, o_id, count,
 				/* is_gid= */ false,
 				/* is_newidmap= */ false)) {
@@ -762,7 +828,10 @@ std::unique_ptr<nsj_t> parseArgs(int argc, char* argv[]) {
 			std::string i_id = argFromVec(subopts, 0);
 			std::string o_id = argFromVec(subopts, 1);
 			std::string cnt = argFromVec(subopts, 2);
-			size_t count = strtoul(cnt.c_str(), nullptr, 0);
+			size_t count = 0;
+			if (!parseMappingCount("group", cnt, &count)) {
+				return nullptr;
+			}
 			if (!user::parseId(nsj.get(), i_id, o_id, count,
 				/* is_gid= */ true,
 				/* is_newidmap= */ false)) {
@@ -774,7 +843,10 @@ std::unique_ptr<nsj_t> parseArgs(int argc, char* argv[]) {
 			std::string i_id = argFromVec(subopts, 0);
 			std::string o_id = argFromVec(subopts, 1);
 			std::string cnt = argFromVec(subopts, 2);
-			size_t count = strtoul(cnt.c_str(), nullptr, 0);
+			size_t count = 0;
+			if (!parseMappingCount("uid_mapping", cnt, &count)) {
+				return nullptr;
+			}
 			if (!user::parseId(nsj.get(), i_id, o_id, count,
 				/* is_gid= */ false,
 				/* is_newidmap= */ true)) {
@@ -786,7 +858,10 @@ std::unique_ptr<nsj_t> parseArgs(int argc, char* argv[]) {
 			std::string i_id = argFromVec(subopts, 0);
 			std::string o_id = argFromVec(subopts, 1);
 			std::string cnt = argFromVec(subopts, 2);
-			size_t count = strtoul(cnt.c_str(), nullptr, 0);
+			size_t count = 0;
+			if (!parseMappingCount("gid_mapping", cnt, &count)) {
+				return nullptr;
+			}
 			if (!user::parseId(nsj.get(), i_id, o_id, count,
 				/* is_gid= */ true,
 				/* is_newidmap= */ true)) {
@@ -920,42 +995,66 @@ std::unique_ptr<nsj_t> parseArgs(int argc, char* argv[]) {
 		case 0x709:
 			nsj->njc.set_use_core_scheduling(true);
 			break;
-		case 0x801:
-			nsj->njc.set_cgroup_mem_max((size_t)strtoull(optarg, NULL, 0));
-			break;
+		case 0x801: {
+			uint64_t value = 0;
+			if (!parseUnsignedOption("cgroup_mem_max", optarg, &value)) {
+				return nullptr;
+			}
+			nsj->njc.set_cgroup_mem_max(value);
+		} break;
 		case 0x802:
 			nsj->njc.set_cgroup_mem_mount(optarg);
 			break;
 		case 0x803:
 			nsj->njc.set_cgroup_mem_parent(optarg);
 			break;
-		case 0x804:
-			nsj->njc.set_cgroup_mem_memsw_max((size_t)strtoull(optarg, NULL, 0));
-			break;
-		case 0x805:
-			nsj->njc.set_cgroup_mem_swap_max((ssize_t)strtoll(optarg, NULL, 0));
-			break;
-		case 0x811:
-			nsj->njc.set_cgroup_pids_max((unsigned int)strtoul(optarg, NULL, 0));
-			break;
+		case 0x804: {
+			uint64_t value = 0;
+			if (!parseUnsignedOption("cgroup_mem_memsw_max", optarg, &value)) {
+				return nullptr;
+			}
+			nsj->njc.set_cgroup_mem_memsw_max(value);
+		} break;
+		case 0x805: {
+			int64_t value = 0;
+			if (!parseSignedOption("cgroup_mem_swap_max", optarg, &value)) {
+				return nullptr;
+			}
+			nsj->njc.set_cgroup_mem_swap_max(value);
+		} break;
+		case 0x811: {
+			uint64_t value = 0;
+			if (!parseUnsignedOption("cgroup_pids_max", optarg, &value)) {
+				return nullptr;
+			}
+			nsj->njc.set_cgroup_pids_max(value);
+		} break;
 		case 0x812:
 			nsj->njc.set_cgroup_pids_mount(optarg);
 			break;
 		case 0x813:
 			nsj->njc.set_cgroup_pids_parent(optarg);
 			break;
-		case 0x821:
-			nsj->njc.set_cgroup_net_cls_classid((unsigned int)strtoul(optarg, NULL, 0));
-			break;
+		case 0x821: {
+			uint32_t value = 0;
+			if (!parseUnsignedOption("cgroup_net_cls_classid", optarg, &value)) {
+				return nullptr;
+			}
+			nsj->njc.set_cgroup_net_cls_classid(value);
+		} break;
 		case 0x822:
 			nsj->njc.set_cgroup_net_cls_mount(optarg);
 			break;
 		case 0x823:
 			nsj->njc.set_cgroup_net_cls_parent(optarg);
 			break;
-		case 0x831:
-			nsj->njc.set_cgroup_cpu_ms_per_sec((unsigned int)strtoul(optarg, NULL, 0));
-			break;
+		case 0x831: {
+			uint32_t value = 0;
+			if (!parseUnsignedOption("cgroup_cpu_ms_per_sec", optarg, &value)) {
+				return nullptr;
+			}
+			nsj->njc.set_cgroup_cpu_ms_per_sec(value);
+		} break;
 		case 0x832:
 			nsj->njc.set_cgroup_cpu_mount(optarg);
 			break;
@@ -986,12 +1085,20 @@ std::unique_ptr<nsj_t> parseArgs(int argc, char* argv[]) {
 		case 0x906:
 			nsj->njc.set_seccomp_unotify_report(optarg);
 			break;
-		case 0x903:
-			nsj->njc.set_nice_level((int)strtol(optarg, NULL, 0));
-			break;
-		case 0x800:
-			nsj->njc.set_oom_score_adj((int32_t)strtol(optarg, NULL, 0));
-			break;
+		case 0x903: {
+			int32_t value = 0;
+			if (!parseSignedOption("nice_level", optarg, &value)) {
+				return nullptr;
+			}
+			nsj->njc.set_nice_level(value);
+		} break;
+		case 0x800: {
+			int32_t value = 0;
+			if (!parseSignedOption("oom_score_adj", optarg, &value)) {
+				return nullptr;
+			}
+			nsj->njc.set_oom_score_adj(value);
+		} break;
 		default:
 			cmdlineUsage(argv[0]);
 			return nullptr;

--- a/user.cc
+++ b/user.cc
@@ -38,6 +38,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <limits>
+
 #include "logs.h"
 #include "macros.h"
 #include "subproc.h"
@@ -322,8 +324,9 @@ static uid_t parseUid(const std::string& id) {
 	if (pw != nullptr) {
 		return pw->pw_uid;
 	}
-	if (util::isANumber(id.c_str())) {
-		return (uid_t)strtoimax(id.c_str(), NULL, 0);
+	uint64_t parsed = 0;
+	if (util::parseUint64(id.c_str(), &parsed) && parsed <= std::numeric_limits<uid_t>::max()) {
+		return (uid_t)parsed;
 	}
 	return (uid_t)-1;
 }
@@ -336,8 +339,9 @@ static gid_t parseGid(const std::string& id) {
 	if (gr != nullptr) {
 		return gr->gr_gid;
 	}
-	if (util::isANumber(id.c_str())) {
-		return (gid_t)strtoimax(id.c_str(), NULL, 0);
+	uint64_t parsed = 0;
+	if (util::parseUint64(id.c_str(), &parsed) && parsed <= std::numeric_limits<gid_t>::max()) {
+		return (gid_t)parsed;
 	}
 	return (gid_t)-1;
 }

--- a/util.cc
+++ b/util.cc
@@ -43,6 +43,7 @@
 #include <unistd.h>
 
 #include <iomanip>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -326,12 +327,36 @@ const std::string StrQuote(const std::string& str) {
 	return ss.str();
 }
 
-bool isANumber(const char* s) {
-	for (; *s; s++) {
-		if (!isdigit(*s) && *s != 'x') {
-			return false;
-		}
+bool parseInt64(const char* str, int64_t* value) {
+	if (str == nullptr || str[0] == '\0' || isspace((unsigned char)str[0])) {
+		return false;
 	}
+
+	errno = 0;
+	char* end = nullptr;
+	intmax_t parsed = strtoimax(str, &end, 0);
+	if (errno == ERANGE || end == str || *end != '\0' ||
+	    parsed < std::numeric_limits<int64_t>::min() ||
+	    parsed > std::numeric_limits<int64_t>::max()) {
+		return false;
+	}
+	*value = (int64_t)parsed;
+	return true;
+}
+
+bool parseUint64(const char* str, uint64_t* value) {
+	if (str == nullptr || str[0] == '\0' || str[0] == '-' || isspace((unsigned char)str[0])) {
+		return false;
+	}
+
+	errno = 0;
+	char* end = nullptr;
+	uintmax_t parsed = strtoumax(str, &end, 0);
+	if (errno == ERANGE || end == str || *end != '\0' ||
+	    parsed > std::numeric_limits<uint64_t>::max()) {
+		return false;
+	}
+	*value = (uint64_t)parsed;
 	return true;
 }
 

--- a/util.h
+++ b/util.h
@@ -65,7 +65,8 @@ std::string* StrAppend(std::string* str, const char* format, ...)
 std::string StrPrintf(const char* format, ...) __attribute__((format(printf, 1, 2)));
 const std::string StrQuote(const std::string& str);
 bool StrEq(const std::string_view& s1, const std::string_view& s2);
-bool isANumber(const char* s);
+bool parseInt64(const char* str, int64_t* value);
+bool parseUint64(const char* str, uint64_t* value);
 uint64_t rnd64(void);
 const std::string sigName(int signo);
 const std::string rLimName(int res);


### PR DESCRIPTION
## Summary

- require complete, in-range integer parsing for numeric command-line options
- reject negative unsigned values and conversions that overflow their destination types
- preserve valid decimal, octal, hexadecimal, signed-option, and special rlimit syntax
- add a focused `test-cmdline` target for malformed and valid values

## Motivation

The existing `strto*` calls did not check whether the entire argument was consumed and, in several cases, narrowed values without a range check. Inputs such as `--time_limit 1.5` could therefore be silently truncated or leave configured defaults in effect. For resource and cgroup limits, that can make a sandbox less restrictive than the operator intended.

The strict helpers are also used for UID/GID input and mapping counts so malformed numeric-looking identities cannot pass through partial conversion.

Fixes #273.

## Testing

- `docker build --target build -t nsjail-strict-cli .`
- `docker run --rm nsjail-strict-cli make -C /nsjail test-cmdline`
- privileged standalone smoke test with `/bin/true`
- `clang-format --dry-run --Werror` on all changed regions
