### PR TITLE
mnt: apply per-mount nosuid/nodev/noexec recursively to recursive binds

### DIFF
--- a/mnt_legacy.cc
+++ b/mnt_legacy.cc
@@ -31,6 +31,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <memory>
 #include <string>
 #include <vector>
@@ -263,23 +264,73 @@ static unsigned long computeRemountFlags(const mount_t& mpt, const struct statvf
 	return flags;
 }
 
+static bool remountOne(const std::string& path, const mnt::mount_t& mpt) {
+	struct statvfs vfs;
+	if (TEMP_FAILURE_RETRY(statvfs(path.c_str(), &vfs)) == -1) {
+		PLOG_W("statvfs('%s')", path.c_str());
+		return false;
+	}
+
+	unsigned long flags = computeRemountFlags(mpt, vfs);
+	LOG_D("Remounting '%s' with flags: %s", path.c_str(), mnt::flagsToStr(flags).c_str());
+
+	if (mount(path.c_str(), path.c_str(), nullptr, flags, nullptr) == -1) {
+		PLOG_W("mount('%s', flags=%s)", path.c_str(), mnt::flagsToStr(flags).c_str());
+		return false;
+	}
+	return true;
+}
+
 bool remountPt(mnt::mount_t& mpt) {
 	if (!mpt.mounted || mpt.mpt->is_symlink()) {
 		return true;
 	}
 
-	struct statvfs vfs;
-	if (TEMP_FAILURE_RETRY(statvfs(mpt.dst.c_str(), &vfs)) == -1) {
-		PLOG_W("statvfs('%s')", mpt.dst.c_str());
+	if (!remountOne(mpt.dst, mpt)) {
 		return false;
 	}
 
-	unsigned long flags = computeRemountFlags(mpt, vfs);
-	LOG_D("Remounting '%s' with flags: %s", mpt.dst.c_str(), mnt::flagsToStr(flags).c_str());
-
-	if (mount(mpt.dst.c_str(), mpt.dst.c_str(), nullptr, flags, nullptr) == -1) {
-		PLOG_W("mount('%s', flags=%s)", mpt.dst.c_str(), mnt::flagsToStr(flags).c_str());
-		return false;
+	/*
+	 * Every bind is forced recursive (MS_REC), so a bind whose source subtree
+	 * contains nested mounts clones those submounts into the jail. The MS_REMOUNT
+	 * above re-applies the requested per-mount flags (nosuid/nodev/noexec/...) only
+	 * to the top mount, leaving nested submounts with their original
+	 * suid/dev/exec-permitting attributes. Re-apply the flags to each submount so
+	 * the requested restrictions cover the whole cloned subtree -- matching the
+	 * recursive read-only pass and the new-mount-API backend, which applies the
+	 * attributes with mount_setattr(AT_RECURSIVE).
+	 */
+	if (mpt.flags & MS_REC) {
+		FILE* f = fopen("/proc/self/mountinfo", "re");
+		if (f != nullptr) {
+			char* line = nullptr;
+			size_t len = 0;
+			const std::string prefix = (mpt.dst == "/") ? "/" : (mpt.dst + "/");
+			while (getline(&line, &len, f) != -1) {
+				/* mountinfo field 5 (0-indexed 4) is the mount point */
+				char* p = line;
+				for (int i = 0; i < 4 && p != nullptr; i++) {
+					p = strchr(p, ' ');
+					if (p != nullptr) {
+						p++;
+					}
+				}
+				if (p == nullptr) {
+					continue;
+				}
+				char* endp = strchr(p, ' ');
+				if (endp == nullptr) {
+					continue;
+				}
+				std::string mp(p, endp - p);
+				if (mp != mpt.dst && mp.compare(0, prefix.size(), prefix) == 0) {
+					/* best-effort; remountOne logs any submount it can't re-flag */
+					remountOne(mp, mpt);
+				}
+			}
+			free(line);
+			fclose(f);
+		}
 	}
 	return true;
 }

--- a/mnt_newapi.cc
+++ b/mnt_newapi.cc
@@ -84,7 +84,7 @@ std::unique_ptr<std::string> buildMountTree(nsj_t*, std::vector<mnt::mount_t>*) 
 namespace mnt {
 namespace newapi {
 
-static bool applyMountFlags(int fd, uintptr_t flags, bool log_error = true) {
+static bool applyMountFlags(int fd, uintptr_t flags, bool log_error = true, bool recursive = false) {
 	struct mount_attr attr = {};
 
 	if (flags & MS_RDONLY) {
@@ -101,7 +101,8 @@ static bool applyMountFlags(int fd, uintptr_t flags, bool log_error = true) {
 	}
 
 	if (util::syscall(__NR_mount_setattr, (uintptr_t)fd, (uintptr_t)"",
-		(uintptr_t)AT_EMPTY_PATH, (uintptr_t)&attr, sizeof(attr)) < 0) {
+		(uintptr_t)(AT_EMPTY_PATH | (recursive ? AT_RECURSIVE : 0)), (uintptr_t)&attr,
+		sizeof(attr)) < 0) {
 		if (log_error) {
 			PLOG_W("mount_setattr(fd=%d, flags=0x%" PRIx64 ")", fd,
 			    (uint64_t)attr.attr_set);
@@ -392,8 +393,16 @@ static bool doBindMountAt(mount_t* mpt, int root_fd, const char* rel_dst) {
 		return false;
 	}
 
-	/* Apply non-RO flags now; RO applied later via remount */
-	if (!applyMountFlags(mnt_fd, mpt->flags & ~MS_RDONLY)) {
+	/*
+	 * Apply non-RO flags now; RO applied later via remount.
+	 * When the bind is recursive (MS_REC), open_tree above cloned the whole
+	 * subtree (AT_RECURSIVE), so the nosuid/nodev/noexec attributes must be
+	 * applied recursively as well -- otherwise nested submounts of the source
+	 * keep their original suid/dev/exec-permitting attributes inside the jail.
+	 * This mirrors the recursive read-only pass done later on the root.
+	 */
+	if (!applyMountFlags(
+		mnt_fd, mpt->flags & ~MS_RDONLY, true, (mpt->flags & MS_REC) != 0)) {
 		LOG_W("Failed to apply mount flags to '%s'", rel_dst);
 	}
 


### PR DESCRIPTION
Every bind mount is forced recursive (MS_REC is OR'd on in prepareMountPoint), so the source subtree -- including any nested submounts -- is cloned into the jail. The requested per-mount flags (nosuid/nodev/noexec) were only applied to the top mount:
 - newapi: applyMountFlags() called mount_setattr() with AT_EMPTY_PATH only, even though doBindMountAt() clones the tree with open_tree(AT_RECURSIVE);
 - legacy: remountPt() issued a single non-recursive MS_REMOUNT|MS_BIND on dst.

As a result, a bind whose source subtree contains a nested mount (a dev-bearing fs, or one holding a setuid binary) kept that submount's original dev/suid/exec-permitting attributes inside the jail, so an explicitly requested nodev/nosuid was not enforced on it. The recursive read-only pass already applies MOUNT_ATTR_RDONLY with AT_RECURSIVE, so the restriction flags were the only per-mount attributes left non-recursive.

Apply the flags recursively when the bind is recursive: thread a `recursive` bool into the newapi applyMountFlags() (OR AT_RECURSIVE into mount_setattr), and re-apply the flags to every submount under dst in the legacy remountPt() by walking /proc/self/mountinfo.

Verified (legacy backend): with a nodev,nosuid recursive bind of a tree containing a nested tmpfs, the nested submount inside the jail now shows nosuid,nodev (previously it kept the host's dev/suid-honoring attributes).