### PR TITLE
contain: stop setup if PR_SET_NO_NEW_PRIVS fails

### DIFF
--- a/contain.cc
+++ b/contain.cc
@@ -82,8 +82,8 @@ static bool containDropPrivs(nsj_t* nsj) {
 #endif
 	if (!nsj->njc.disable_no_new_privs()) {
 		if (prctl(PR_SET_NO_NEW_PRIVS, 1UL, 0UL, 0UL, 0UL) == -1) {
-			/* Only new kernels support it */
-			PLOG_W("prctl(PR_SET_NO_NEW_PRIVS, 1)");
+			PLOG_E("prctl(PR_SET_NO_NEW_PRIVS, 1)");
+			return false;
 		}
 	}
 


### PR DESCRIPTION
## Summary

When nsjail is configured to set `no_new_privs`, a failed `prctl(PR_SET_NO_NEW_PRIVS, 1)` call currently produces a warning and lets the jailed command continue.

Treat the failed call as an error and stop setup before executing the command. This does not change the explicit `--disable_no_new_privs` path.

## Testing

The full build passes on Ubuntu 24.04 under WSL. Basic true/false execution tests and the seccomp tests also pass.

I used strace syscall injection to force the `PR_SET_NO_NEW_PRIVS` call to return `EPERM`. nsjail stopped setup and did not execute the jailed command. The same command still ran when invoked with `--disable_no_new_privs`.

The remaining test suite reached the networking tests, then stopped because `pasta` is not installed.
