### PR TITLE
user: fail closed when supplementary groups cannot be set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,11 @@ test: $(BIN)
 	# --- Basic sanity tests ---
 	$(call run_test, ./nsjail -q -Mo --chroot / --user 99999 --group 99999 -- /bin/true, 0)
 	$(call run_test, ./nsjail -q -Mo --chroot / --user 99999 --group 99999 -- /bin/false, 1)
+	$(call run_test, strace -f -qq -e inject=setgroups:error=EPERM ./nsjail -q -Mo --disable_clone_newuser --chroot / --user 99999 --group 99999 -- /bin/true, 255)
+ifeq ($(UID),0)
+	$(call run_test, setpriv --reuid 1000 --regid 1000 --groups 1234 -- ./nsjail -q -Mo --user 65534 --group 65534 --disable_clone_newnet --disable_clone_newcgroup --disable_clone_newns --disable_clone_newpid --disable_clone_newipc --disable_clone_newuts --disable_proc -- /bin/true, 255)
+	$(call run_test, setpriv --reuid 1000 --regid 1000 --clear-groups -- ./nsjail -q -Mo --user 65534 --group 65534 --disable_clone_newnet --disable_clone_newcgroup --disable_clone_newns --disable_clone_newpid --disable_clone_newipc --disable_clone_newuts --disable_proc -- /bin/true, 0)
+endif
 	$(call run_test, ./nsjail --config tests/seccomp.cfg -q -t 2 -- /bin/bash -c 'strace -o /dev/null /bin/true || exit 77', 77)
 	$(call run_test, ./nsjail --config tests/basic.cfg -q -t 2 -- /bin/bash -c 'strace -o /dev/null /bin/true && exit 77', 77)
 	$(call run_test, ./nsjail --config tests/pasta-nat.cfg -q -t 3 -- /bin/bash -c 'sleep 0.2; ping -W 1 -c 1 8.8.8.8 && exit 77', 77)

--- a/user.cc
+++ b/user.cc
@@ -102,12 +102,16 @@ static bool hasGidMapSelf(nsj_t* nsj) {
 	return false;
 }
 
+static bool shouldDenySetGroups(nsj_t* nsj) {
+	return nsj->njc.clone_newuser() && nsj->orig_euid != 0 && hasGidMapSelf(nsj);
+}
+
 static bool setGroupsDeny(nsj_t* nsj, pid_t pid) {
 	/*
 	 * No need to write 'deny' to /proc/pid/setgroups if our euid==0, as writing to
 	 * uid_map/gid_map will succeed anyway
 	 */
-	if (!nsj->njc.clone_newuser() || nsj->orig_euid == 0 || !hasGidMapSelf(nsj)) {
+	if (!shouldDenySetGroups(nsj)) {
 		return true;
 	}
 
@@ -288,11 +292,27 @@ bool initNsFromChild(nsj_t* nsj) {
 
 	LOG_D("setgroups(%zu, %s)", groups.size(), groupsString.c_str());
 	if (setgroups(groups.size(), groups.data()) == -1) {
-		/* Indicate error if specific groups were requested */
-		if (groups.size() > 0) {
+		const int setgroupsErrno = errno;
+		/* EPERM is expected after the parent writes "deny" to /proc/pid/setgroups. */
+		if (!shouldDenySetGroups(nsj) || setgroupsErrno != EPERM) {
+			errno = setgroupsErrno;
 			PLOG_E("setgroups(%zu, %s) failed", groups.size(), groupsString.c_str());
 			return false;
 		}
+
+		const int remainingGroups = getgroups(0, nullptr);
+		if (remainingGroups == -1) {
+			PLOG_E("getgroups(0, nullptr) failed");
+			return false;
+		}
+		if (remainingGroups != 0) {
+			errno = setgroupsErrno;
+			PLOG_E("setgroups(%zu, %s) failed and %d supplementary group(s) remain",
+			    groups.size(), groupsString.c_str(), remainingGroups);
+			return false;
+		}
+
+		errno = setgroupsErrno;
 		PLOG_D("setgroups(%zu, %s) failed", groups.size(), groupsString.c_str());
 	}
 


### PR DESCRIPTION
## Summary

- fail sandbox setup when supplementary groups cannot be configured
- preserve the expected `EPERM` path only when the parent deliberately denied `setgroups(2)` and no supplementary groups remain
- add regressions for unexpected failure, inherited groups, and the clean expected-`EPERM` case

## Security rationale

`setresgid()` and `setresuid()` do not clear supplementary groups. If `setgroups(2)` fails and nsjail continues, a jailed command can retain group-based access held by its launcher.

The original change made unexpected `setgroups(2)` failures fatal, while preserving the `EPERM` that follows an intentional `deny` write to `/proc/<pid>/setgroups` in an unprivileged user namespace. Further testing found that this expected-error path also needs to verify the resulting credentials: `CLONE_NEWUSER` inherits supplementary groups, and `deny` prevents the child from clearing them.

With nsjail launched as UID/GID `1000` and inherited supplementary GID `1234`, the current PR baseline wrote `deny`, received `EPERM`, and still executed the jailed command. `/proc/self/status` confirmed one supplementary group remained:

```text
Groups: 65534
```

The namespace renders the unmapped GID as the overflow value, but the credential still carries the host group membership. This can preserve access to group-readable host files exposed to the jail.

The updated patch shares the exact parent-side `setgroups`-deny predicate with the child. Every unexpected failure stops before `execve`; after the expected `EPERM`, it calls `getgroups(0, nullptr)` and proceeds only if the supplementary-group count is zero.

## Verification

- native ARM64 Linux Docker build with the project's `-Werror` flags
- current PR baseline with inherited GID `1234`: exited `0` and retained one supplementary group
- patched build with the same launch: exited `255` before `execve`
- patched build with no inherited supplementary groups: exited `0`
- `strace -e inject=setgroups:error=EPERM` without the intentional deny path: exited `255`
- all three new Makefile regression cases passed
- basic true/false and local seccomp configuration tests passed
- `git diff --check`

The broader integration target then reached its existing `pasta` networking test and stopped because the minimal test container did not include the optional `pasta` executable.
