### PR TITLE
contain: retain proc fd directory for descriptor sealing

### DIFF
--- a/contain.cc
+++ b/contain.cc
@@ -286,25 +286,43 @@ static bool containMakeFdsCOENaive(nsj_t* nsj) {
 	return true;
 }
 
-static bool containMakeFdsCOEProc(nsj_t* nsj) {
+static DIR* containOpenProcFdDir() {
 	int dirfd = open("/proc/self/fd", O_DIRECTORY | O_RDONLY | O_CLOEXEC);
 	if (dirfd == -1) {
 		PLOG_D("open('/proc/self/fd', O_DIRECTORY|O_RDONLY|O_CLOEXEC)");
-		return false;
+		return nullptr;
 	}
 	DIR* dir = fdopendir(dirfd);
 	if (dir == nullptr) {
 		PLOG_W("fdopendir(fd=%d)", dirfd);
 		close(dirfd);
-		return false;
+		return nullptr;
 	}
+	return dir;
+}
+
+static bool containMakeFdsCOEProc(nsj_t* nsj, DIR* proc_fd_dir) {
+	bool owned_dir = false;
+	if (proc_fd_dir == nullptr) {
+		proc_fd_dir = containOpenProcFdDir();
+		if (proc_fd_dir == nullptr) {
+			return false;
+		}
+		owned_dir = true;
+	}
+	defer {
+		if (owned_dir) {
+			closedir(proc_fd_dir);
+		}
+	};
+	rewinddir(proc_fd_dir);
+
 	/* Make all fds above stderr close-on-exec */
 	for (;;) {
 		errno = 0;
-		struct dirent* entry = readdir(dir);
+		struct dirent* entry = readdir(proc_fd_dir);
 		if (entry == nullptr && errno != 0) {
 			PLOG_D("readdir('/proc/self/fd')");
-			closedir(dir);
 			return false;
 		}
 		if (entry == nullptr) {
@@ -325,20 +343,18 @@ static bool containMakeFdsCOEProc(nsj_t* nsj) {
 		int flags = TEMP_FAILURE_RETRY(fcntl(fd, F_GETFD, 0));
 		if (flags == -1) {
 			PLOG_D("fcntl(fd=%d, F_GETFD, 0)", fd);
-			closedir(dir);
 			return false;
 		}
 		RETURN_ON_FAILURE(containMakeFdCOE(fd, containPassFd(nsj, fd)));
 	}
-	closedir(dir);
 	return true;
 }
 
-static bool containMakeFdsCOE(nsj_t* nsj) {
+static bool containMakeFdsCOE(nsj_t* nsj, DIR* proc_fd_dir) {
 	if (containMakeFdsCOECloseRange(nsj)) {
 		return true;
 	}
-	if (containMakeFdsCOEProc(nsj)) {
+	if (containMakeFdsCOEProc(nsj, proc_fd_dir)) {
 		return true;
 	}
 	if (containMakeFdsCOENaive(nsj)) {
@@ -380,8 +396,20 @@ bool setupFD(nsj_t* nsj, int fd_in, int fd_out, int fd_err) {
 }
 
 bool containProc(nsj_t* nsj) {
+	DIR* proc_fd_dir = nullptr;
+	defer {
+		if (proc_fd_dir != nullptr) {
+			closedir(proc_fd_dir);
+		}
+	};
+
 	RETURN_ON_FAILURE(containUserNs(nsj));
 	RETURN_ON_FAILURE(containInitPidNs(nsj));
+	/*
+	 * Keep the parent /proc fd directory available after mount namespace setup, so the
+	 * close_range() fallback can still enumerate all descriptors before execve().
+	 */
+	proc_fd_dir = containOpenProcFdDir();
 	RETURN_ON_FAILURE(containInitMountNs(nsj));
 	RETURN_ON_FAILURE(containInitNetNs(nsj));
 	RETURN_ON_FAILURE(containInitUtsNs(nsj));
@@ -395,7 +423,7 @@ bool containProc(nsj_t* nsj) {
 	RETURN_ON_FAILURE(containTSC(nsj));
 	RETURN_ON_FAILURE(containSetLimits(nsj));
 	RETURN_ON_FAILURE(containPrepareEnv(nsj));
-	RETURN_ON_FAILURE(containMakeFdsCOE(nsj));
+	RETURN_ON_FAILURE(containMakeFdsCOE(nsj, proc_fd_dir));
 
 	return true;
 }


### PR DESCRIPTION
## Problem

The final descriptor-sealing pass first tries
`close_range(..., CLOSE_RANGE_CLOEXEC)`, then enumerates `/proc/self/fd`,
then falls back to scanning descriptor numbers 0 through 1023.

When `close_range()` is unavailable or denied and mount/chroot setup hides
`/proc`, inherited descriptors above 1023 are not marked close-on-exec and can
survive into the jailed target.

## Change

Open `/proc/self/fd` before mount namespace setup and retain that directory
stream until the final descriptor-sealing pass. The pass can then enumerate the
complete final descriptor set even when the configured jail does not expose
`/proc`.

The existing order is preserved:

1. use `close_range()` when available;
2. enumerate the retained or current proc directory;
3. retain the bounded fallback if neither mechanism is available.

The retained stream is closed by its owner on every `containProc()` return path.

## Verification

- Baseline with `close_range()` forced to return `EPERM`, `--disable_proc`, and
  an inherited descriptor 1500: the target can observe descriptor 1500.
- Patched build under the same conditions: descriptor 1500 is closed before
  target execution.
- Explicit `--pass_fd 1500` remains preserved.
- A closed `--pass_fd` number reused by the retained proc directory is released
  by the stream owner before target execution.
- Standalone-once, standalone-execve, PID namespace, `--execute_fd`, and
  listen-mode paths were exercised.
- The repository Docker build completes with `-Werror`.

This is a hardening change for the process-isolation boundary and does not
change the behavior of explicitly passed descriptors.
