### PR TITLE
Harden jail mounts, capabilities, and nstun networking defaults

### DIFF
--- a/caps.cc
+++ b/caps.cc
@@ -257,28 +257,31 @@ bool initNs(nsj_t* nsj) {
 
 	/*
 	 * Make sure all other caps (those which were not explicitly requested) are removed from the
-	 * bounding set. We need to have CAP_SETPCAP to do that now
+	 * bounding set. We need CAP_SETPCAP to do that; fail closed if we cannot, otherwise a
+	 * residual bounding-set capability can be regained after exec.
 	 */
 	dbgmsg.clear();
-	if (getEffective(cap_data, CAP_SETPCAP)) {
-		for (const auto& i : capNames) {
-			if (getInheritable(cap_data, i.val)) {
-				continue;
-			}
-			if (prctl(PR_CAPBSET_READ, (unsigned long)i.val, 0UL, 0UL, 0UL) == -1 &&
-			    errno == EINVAL) {
-				LOG_D("Skipping unsupported capability: %s", i.name);
-				continue;
-			}
-			dbgmsg.append(" ").append(i.name);
-			if (prctl(PR_CAPBSET_DROP, (unsigned long)i.val, 0UL, 0UL, 0UL) == -1) {
-				PLOG_W("prctl(PR_CAPBSET_DROP, %s)", i.name);
-				return false;
-			}
-		}
-		LOG_D(
-		    "Dropped the following capabilities from the bounding set:%s", dbgmsg.c_str());
+	if (!getEffective(cap_data, CAP_SETPCAP)) {
+		LOG_E("CAP_SETPCAP is not effective; cannot drop unused capabilities from the "
+		      "bounding set");
+		return false;
 	}
+	for (const auto& i : capNames) {
+		if (getInheritable(cap_data, i.val)) {
+			continue;
+		}
+		if (prctl(PR_CAPBSET_READ, (unsigned long)i.val, 0UL, 0UL, 0UL) == -1 &&
+		    errno == EINVAL) {
+			LOG_D("Skipping unsupported capability: %s", i.name);
+			continue;
+		}
+		dbgmsg.append(" ").append(i.name);
+		if (prctl(PR_CAPBSET_DROP, (unsigned long)i.val, 0UL, 0UL, 0UL) == -1) {
+			PLOG_E("prctl(PR_CAPBSET_DROP, %s)", i.name);
+			return false;
+		}
+	}
+	LOG_D("Dropped the following capabilities from the bounding set:%s", dbgmsg.c_str());
 
 	/* Make sure inheritable set is preserved across execve via the modified ambient set */
 	dbgmsg.clear();

--- a/configs/bash-with-fake-geteuid.cfg
+++ b/configs/bash-with-fake-geteuid.cfg
@@ -61,7 +61,10 @@ clone_newipc: true
 clone_newuts: true
 clone_newcgroup: true
 
-user_net { }
+user_net {
+	rule4 { action: ALLOW }
+	rule6 { action: ALLOW }
+}
 
 uidmap {
 	inside_id: "0"

--- a/configs/chromium-with-net-wayland.cfg
+++ b/configs/chromium-with-net-wayland.cfg
@@ -22,7 +22,10 @@ cwd: "/user"
 time_limit: 0
 
 clone_newnet: true
-user_net { }
+user_net {
+	rule4 { action: ALLOW }
+	rule6 { action: ALLOW }
+}
 
 envar: "HOME=/user"
 envar: "DISPLAY"

--- a/configs/firefox-with-net-X11.cfg
+++ b/configs/firefox-with-net-X11.cfg
@@ -22,7 +22,10 @@ cwd: "/user"
 time_limit: 0
 
 clone_newnet: true
-user_net { }
+user_net {
+	rule4 { action: ALLOW }
+	rule6 { action: ALLOW }
+}
 
 envar: "HOME=/user"
 envar: "TMP=/tmp"

--- a/configs/firefox-with-net-wayland.cfg
+++ b/configs/firefox-with-net-wayland.cfg
@@ -22,7 +22,10 @@ cwd: "/user"
 time_limit: 0
 
 clone_newnet: true
-user_net { }
+user_net {
+	rule4 { action: ALLOW }
+	rule6 { action: ALLOW }
+}
 
 envar: "HOME=/user"
 envar: "TMP=/tmp"

--- a/configs/hexchat-with-net.cfg
+++ b/configs/hexchat-with-net.cfg
@@ -32,7 +32,10 @@ rlimit_fsize: 4096
 rlimit_nofile: 128
 
 clone_newnet: true
-user_net { }
+user_net {
+	rule4 { action: ALLOW }
+	rule6 { action: ALLOW }
+}
 
 mount {
 	dst: "/proc"

--- a/configs/telegram.cfg
+++ b/configs/telegram.cfg
@@ -32,7 +32,10 @@ rlimit_fsize: 4096
 rlimit_nofile: 128
 
 clone_newnet: true
-user_net { }
+user_net {
+	rule4 { action: ALLOW }
+	rule6 { action: ALLOW }
+}
 
 mount {
 	dst: "/proc"

--- a/configs/weechat-with-net.cfg
+++ b/configs/weechat-with-net.cfg
@@ -31,7 +31,10 @@ rlimit_fsize: 4096
 rlimit_nofile: 128
 
 clone_newnet: true
-user_net { }
+user_net {
+	rule4 { action: ALLOW }
+	rule6 { action: ALLOW }
+}
 
 mount {
 	dst: "/proc"

--- a/configs/xchat-with-net.cfg
+++ b/configs/xchat-with-net.cfg
@@ -32,7 +32,10 @@ rlimit_fsize: 4096
 rlimit_nofile: 128
 
 clone_newnet: true
-user_net { }
+user_net {
+	rule4 { action: ALLOW }
+	rule6 { action: ALLOW }
+}
 
 mount {
 	dst: "/proc"

--- a/configs/znc-with-net.cfg
+++ b/configs/znc-with-net.cfg
@@ -29,6 +29,8 @@ rlimit_nofile: 128
 
 clone_newnet: true
 user_net {
+        rule4 { action: ALLOW }
+        rule6 { action: ALLOW }
         rule4 {
                 direction: HOST_TO_GUEST
                 action: REDIRECT

--- a/contain.cc
+++ b/contain.cc
@@ -82,8 +82,8 @@ static bool containDropPrivs(nsj_t* nsj) {
 #endif
 	if (!nsj->njc.disable_no_new_privs()) {
 		if (prctl(PR_SET_NO_NEW_PRIVS, 1UL, 0UL, 0UL, 0UL) == -1) {
-			/* Only new kernels support it */
-			PLOG_W("prctl(PR_SET_NO_NEW_PRIVS, 1)");
+			PLOG_E("prctl(PR_SET_NO_NEW_PRIVS, 1)");
+			return false;
 		}
 	}
 

--- a/mnt_legacy.cc
+++ b/mnt_legacy.cc
@@ -51,8 +51,8 @@ static bool isDirectory(const char* path) {
 	return stat(path, &st) == 0 && S_ISDIR(st.st_mode);
 }
 
-static mount_t prepareMountPoint(const nsjail::MountPt& proto) {
-	mount_t mpt = {
+static bool prepareMountPoint(const nsjail::MountPt& proto, mount_t* mpt) {
+	*mpt = {
 	    .mpt = &proto,
 	    .src = "",
 	    .dst = "",
@@ -64,51 +64,58 @@ static mount_t prepareMountPoint(const nsjail::MountPt& proto) {
 
 	if (!proto.prefix_src_env().empty()) {
 		if (const char* env = getenv(proto.prefix_src_env().c_str())) {
-			mpt.src = env;
+			mpt->src = env;
 		} else {
 			LOG_W("Environment variable not set: %s", QC(proto.prefix_src_env()));
-			return mpt;
+			return false;
 		}
 	}
-	mpt.src += proto.src();
+	mpt->src += proto.src();
 
 	if (!proto.prefix_dst_env().empty()) {
 		if (const char* env = getenv(proto.prefix_dst_env().c_str())) {
-			mpt.dst = env;
+			mpt->dst = env;
 		} else {
 			LOG_W("Environment variable not set: %s", QC(proto.prefix_dst_env()));
-			return mpt;
+			return false;
 		}
 	}
-	mpt.dst += proto.dst();
+	mpt->dst += proto.dst();
 
-	mpt.flags = proto.rw() ? 0 : (uintptr_t)MS_RDONLY;
+	std::string safe_dst;
+	if (!util::sanitizeJailRelPath(mpt->dst, &safe_dst)) {
+		LOG_E("Rejecting mount destination that escapes the jail root: %s", QC(mpt->dst));
+		return false;
+	}
+	mpt->dst = std::move(safe_dst);
+
+	mpt->flags = proto.rw() ? 0 : (uintptr_t)MS_RDONLY;
 	if (proto.is_bind()) {
-		mpt.flags |= MS_BIND | MS_REC | MS_PRIVATE;
+		mpt->flags |= MS_BIND | MS_REC | MS_PRIVATE;
 	}
 	if (proto.nosuid()) {
-		mpt.flags |= MS_NOSUID;
+		mpt->flags |= MS_NOSUID;
 	}
 	if (proto.nodev()) {
-		mpt.flags |= MS_NODEV;
+		mpt->flags |= MS_NODEV;
 	}
 	if (proto.noexec()) {
-		mpt.flags |= MS_NOEXEC;
+		mpt->flags |= MS_NOEXEC;
 	}
 
 	if (proto.has_is_dir()) {
-		mpt.is_dir = proto.is_dir();
+		mpt->is_dir = proto.is_dir();
 	} else if (!proto.src_content().empty()) {
-		mpt.is_dir = false;
-	} else if (mpt.src.empty()) {
-		mpt.is_dir = true;
-	} else if (mpt.flags & MS_BIND) {
-		mpt.is_dir = isDirectory(mpt.src.c_str());
+		mpt->is_dir = false;
+	} else if (mpt->src.empty()) {
+		mpt->is_dir = true;
+	} else if (mpt->flags & MS_BIND) {
+		mpt->is_dir = isDirectory(mpt->src.c_str());
 	} else {
-		mpt.is_dir = true;
+		mpt->is_dir = true;
 	}
 
-	return mpt;
+	return true;
 }
 
 static int tryMountRW(mount_t* mpt, const char* src, const char* dst) {
@@ -251,11 +258,15 @@ static unsigned long computeRemountFlags(const mount_t& mpt, const struct statvf
 	};
 
 	const unsigned long per_mountpoint_flags =
-	    MS_LAZYTIME | MS_MANDLOCK | MS_NOATIME | MS_NODEV | MS_NODIRATIME | MS_NOEXEC |
-	    MS_NOSUID | MS_RELATIME | MS_RDONLY | MS_SYNCHRONOUS | MS_NOSYMFOLLOW;
+	    MS_LAZYTIME | MS_NOATIME | MS_NODEV | MS_NODIRATIME | MS_NOEXEC | MS_NOSUID |
+	    MS_RELATIME | MS_RDONLY | MS_SYNCHRONOUS | MS_NOSYMFOLLOW;
 
 	unsigned long flags = MS_REMOUNT | MS_BIND | (mpt.flags & per_mountpoint_flags);
 	for (const auto& i : mountPairs) {
+		/* Do not re-introduce MS_MANDLOCK from the underlying vfs unless requested */
+		if (i.mount_flag == MS_MANDLOCK && !(mpt.flags & MS_MANDLOCK)) {
+			continue;
+		}
 		if (vfs.f_flag & i.vfs_flag) {
 			flags |= i.mount_flag;
 		}
@@ -320,7 +331,17 @@ std::unique_ptr<std::string> buildMountTree(nsj_t* nsj, std::vector<mnt::mount_t
 	}
 
 	for (const auto& proto : nsj->njc.mount()) {
-		mount_t mpt = prepareMountPoint(proto);
+		mount_t mpt;
+		if (!prepareMountPoint(proto, &mpt)) {
+			if (proto.mandatory()) {
+				LOG_E("Failed to prepare mandatory mount point: %s",
+				    mnt::describeMountPt(proto).c_str());
+				return nullptr;
+			}
+			LOG_W("Skipping invalid non-mandatory mount point: %s",
+			    mnt::describeMountPt(proto).c_str());
+			continue;
+		}
 
 		if (!mountSinglePoint(&mpt, destdir->c_str(), tmpdir->c_str())) {
 			if (mpt.mpt->mandatory()) {

--- a/mnt_newapi.cc
+++ b/mnt_newapi.cc
@@ -153,11 +153,15 @@ static unsigned long computeLegacyRemountFlags(const mount_t& mpt, const struct 
 	};
 
 	const unsigned long per_mountpoint_flags =
-	    MS_LAZYTIME | MS_MANDLOCK | MS_NOATIME | MS_NODEV | MS_NODIRATIME | MS_NOEXEC |
-	    MS_NOSUID | MS_RELATIME | MS_RDONLY | MS_SYNCHRONOUS | MS_NOSYMFOLLOW;
+	    MS_LAZYTIME | MS_NOATIME | MS_NODEV | MS_NODIRATIME | MS_NOEXEC | MS_NOSUID |
+	    MS_RELATIME | MS_RDONLY | MS_SYNCHRONOUS | MS_NOSYMFOLLOW;
 
 	unsigned long flags = MS_REMOUNT | MS_BIND | (mpt.flags & per_mountpoint_flags);
 	for (const auto& i : mountPairs) {
+		/* Do not re-introduce MS_MANDLOCK from the underlying vfs unless requested */
+		if (i.mount_flag == MS_MANDLOCK && !(mpt.flags & MS_MANDLOCK)) {
+			continue;
+		}
 		if (vfs.f_flag & i.vfs_flag) {
 			flags |= i.mount_flag;
 		}
@@ -202,8 +206,12 @@ static bool createDirAt(int dir_fd, const char* path, mode_t mode) {
 
 	std::string cumulative;
 	for (const auto& component : util::strSplit(path, '/')) {
-		if (component.empty()) {
+		if (component.empty() || component == ".") {
 			continue;
+		}
+		if (component == "..") {
+			LOG_W("Refusing '..' in createDirAt('%s')", path);
+			return false;
 		}
 
 		if (!cumulative.empty()) {
@@ -354,7 +362,10 @@ static bool mountDynamicContentAt(mount_t* mpt, int root_fd, const char* rel_dst
 	}
 
 	if (!applyMountFlags(mnt_fd, mpt->flags & ~MS_RDONLY)) {
-		LOG_W("Failed to apply mount flags to '%s'", rel_dst);
+		LOG_E("Failed to apply mount flags to '%s'", rel_dst);
+		close(mnt_fd);
+		unlinkat(root_fd, src_rel.c_str(), 0);
+		return false;
 	}
 
 	if (util::syscall(__NR_move_mount, (uintptr_t)mnt_fd, (uintptr_t)"", (uintptr_t)root_fd,
@@ -394,7 +405,9 @@ static bool doBindMountAt(mount_t* mpt, int root_fd, const char* rel_dst) {
 
 	/* Apply non-RO flags now; RO applied later via remount */
 	if (!applyMountFlags(mnt_fd, mpt->flags & ~MS_RDONLY)) {
-		LOG_W("Failed to apply mount flags to '%s'", rel_dst);
+		LOG_E("Failed to apply mount flags to '%s'", rel_dst);
+		close(mnt_fd);
+		return false;
 	}
 
 	if (util::syscall(__NR_move_mount, (uintptr_t)mnt_fd, (uintptr_t)"", (uintptr_t)root_fd,
@@ -459,7 +472,9 @@ static bool mountSinglePointAt(mount_t* mpt, int root_fd) {
 	}
 
 	if (!applyMountFlags(mnt_fd, mpt->flags & ~MS_RDONLY)) {
-		LOG_W("Failed to apply mount flags to '%s'", rel_dst);
+		LOG_E("Failed to apply mount flags to '%s'", rel_dst);
+		close(mnt_fd);
+		return false;
 	}
 
 	if (util::syscall(__NR_move_mount, (uintptr_t)mnt_fd, (uintptr_t)"", (uintptr_t)root_fd,
@@ -473,8 +488,8 @@ static bool mountSinglePointAt(mount_t* mpt, int root_fd) {
 	return openMountForRemount(mpt, root_fd, rel_dst);
 }
 
-static mount_t prepareMountPoint(const nsjail::MountPt& proto) {
-	mount_t mpt = {
+static bool prepareMountPoint(const nsjail::MountPt& proto, mount_t* mpt) {
+	*mpt = {
 	    .mpt = &proto,
 	    .src = "",
 	    .dst = "",
@@ -486,57 +501,64 @@ static mount_t prepareMountPoint(const nsjail::MountPt& proto) {
 
 	if (!proto.prefix_src_env().empty()) {
 		if (const char* env = getenv(proto.prefix_src_env().c_str())) {
-			mpt.src = env;
+			mpt->src = env;
 		} else {
 			LOG_W("Environment variable not set: %s", QC(proto.prefix_src_env()));
-			return mpt;
+			return false;
 		}
 	}
-	mpt.src += proto.src();
+	mpt->src += proto.src();
 
 	if (!proto.prefix_dst_env().empty()) {
 		if (const char* env = getenv(proto.prefix_dst_env().c_str())) {
-			mpt.dst = env;
+			mpt->dst = env;
 		} else {
 			LOG_W("Environment variable not set: %s", QC(proto.prefix_dst_env()));
-			return mpt;
+			return false;
 		}
 	}
-	mpt.dst += proto.dst();
+	mpt->dst += proto.dst();
 
-	mpt.flags = proto.rw() ? 0 : (uintptr_t)MS_RDONLY;
+	std::string safe_dst;
+	if (!util::sanitizeJailRelPath(mpt->dst, &safe_dst)) {
+		LOG_E("Rejecting mount destination that escapes the jail root: %s", QC(mpt->dst));
+		return false;
+	}
+	mpt->dst = std::move(safe_dst);
+
+	mpt->flags = proto.rw() ? 0 : (uintptr_t)MS_RDONLY;
 	if (proto.is_bind()) {
-		mpt.flags |= MS_BIND | MS_REC | MS_PRIVATE;
+		mpt->flags |= MS_BIND | MS_REC | MS_PRIVATE;
 	}
 	if (proto.nosuid()) {
-		mpt.flags |= MS_NOSUID;
+		mpt->flags |= MS_NOSUID;
 	}
 	if (proto.nodev()) {
-		mpt.flags |= MS_NODEV;
+		mpt->flags |= MS_NODEV;
 	}
 	if (proto.noexec()) {
-		mpt.flags |= MS_NOEXEC;
+		mpt->flags |= MS_NOEXEC;
 	}
 	if (proto.has_options()) {
 		for (const auto& opt : util::strSplit(proto.options(), ',')) {
-			applyGenericMountOption(opt, &mpt.flags);
+			applyGenericMountOption(opt, &mpt->flags);
 		}
 	}
 
 	if (proto.has_is_dir()) {
-		mpt.is_dir = proto.is_dir();
+		mpt->is_dir = proto.is_dir();
 	} else if (!proto.src_content().empty()) {
-		mpt.is_dir = false;
-	} else if (mpt.src.empty()) {
-		mpt.is_dir = true;
-	} else if (mpt.flags & MS_BIND) {
+		mpt->is_dir = false;
+	} else if (mpt->src.empty()) {
+		mpt->is_dir = true;
+	} else if (mpt->flags & MS_BIND) {
 		struct stat st;
-		mpt.is_dir = (stat(mpt.src.c_str(), &st) == 0 && S_ISDIR(st.st_mode));
+		mpt->is_dir = (stat(mpt->src.c_str(), &st) == 0 && S_ISDIR(st.st_mode));
 	} else {
-		mpt.is_dir = true;
+		mpt->is_dir = true;
 	}
 
-	return mpt;
+	return true;
 }
 
 bool isAvailable() {
@@ -617,7 +639,17 @@ std::unique_ptr<std::string> buildMountTree(nsj_t* nsj, std::vector<mnt::mount_t
 
 	/* Build entire mount tree using fd-relative operations */
 	for (const auto& proto : nsj->njc.mount()) {
-		mount_t mpt = prepareMountPoint(proto);
+		mount_t mpt;
+		if (!prepareMountPoint(proto, &mpt)) {
+			if (proto.mandatory()) {
+				LOG_E("Failed to prepare mandatory mount point: %s",
+				    mnt::describeMountPt(proto).c_str());
+				return nullptr;
+			}
+			LOG_W("Skipping invalid non-mandatory mount point: %s",
+			    mnt::describeMountPt(proto).c_str());
+			continue;
+		}
 
 		if (!mountSinglePointAt(&mpt, root_fd)) {
 			if (mpt.mpt->mandatory()) {

--- a/nstun/encap.cc
+++ b/nstun/encap.cc
@@ -93,6 +93,9 @@ bool parse_socks5_connect_reply(std::span<const uint8_t> data, Socks5Reply* out)
 		if (data.size() < sizeof(socks5_req6)) return false;
 		const auto* reply = reinterpret_cast<const socks5_req6*>(data.data());
 		memcpy(&out->bind_port, &reply->dst_port, sizeof(reply->dst_port));
+	} else {
+		/* Domain / unknown ATYP: not used by our CONNECT client; fail closed */
+		return false;
 	}
 
 	return true;

--- a/nstun/ip.cc
+++ b/nstun/ip.cc
@@ -102,13 +102,11 @@ void handle_ip4(Context* ctx, std::span<const uint8_t> payload) {
 		return;
 	}
 
-	/* SSRF gate: reject packets to loopback, broadcast, or INADDR_ANY.
-	 * This is the single authoritative check - L4 handlers rely on this
-	 * and do NOT duplicate it. Redirect rules in policy may still target
-	 * loopback intentionally (admin-controlled). */
-	if (IN_LOOPBACK(ntohl(ip->daddr)) || ip->daddr == htonl(INADDR_ANY) ||
-	    ip->daddr == htonl(INADDR_BROADCAST)) {
-		LOG_W("Dropping packet destined to loopback, ANY, or broadcast: %s",
+	/* SSRF gate: reject guest-chosen destinations that must not become host
+	 * connect()/sendto() targets. L4 handlers rely on this and do NOT duplicate it.
+	 * Admin REDIRECT/ENCAP targets are configured separately. */
+	if (is_forbidden_dest4(ip->daddr)) {
+		LOG_W("Dropping packet to forbidden destination: %s",
 		    ip4_to_string(ip->daddr).c_str());
 		return;
 	}
@@ -176,27 +174,11 @@ void handle_ip6(Context* ctx, std::span<const uint8_t> payload) {
 		}
 	}
 
-	/* SSRF gate: reject packets to loopback, v4-mapped, link-local, or site-local.
-	 * This is the single authoritative check - L4 handlers rely on this
-	 * and do NOT duplicate it. Redirect rules in policy may still target
-	 * ::1 intentionally (admin-controlled). */
-	if (IN6_IS_ADDR_LOOPBACK((const struct in6_addr*)ip6->daddr)) {
-		LOG_D("Dropping IPv6 packet to loopback: %s", ip6_to_string(ip6->daddr).c_str());
-		return;
-	}
-	if (IN6_IS_ADDR_V4MAPPED((const struct in6_addr*)ip6->daddr)) {
-		LOG_D("Dropping IPv6 packet to v4-mapped address (use IPv4 directly): %s",
-		    ip6_to_string(ip6->daddr).c_str());
-		return;
-	}
-	if (IN6_IS_ADDR_V4COMPAT((const struct in6_addr*)ip6->daddr)) {
-		LOG_D("Dropping IPv6 packet to v4-compatible address (deprecated): %s",
-		    ip6_to_string(ip6->daddr).c_str());
-		return;
-	}
-	if (IN6_IS_ADDR_LINKLOCAL((const struct in6_addr*)ip6->daddr) ||
-	    IN6_IS_ADDR_SITELOCAL((const struct in6_addr*)ip6->daddr)) {
-		LOG_D("Dropping IPv6 packet to link/site-local address: %s",
+	/* SSRF gate: reject guest-chosen destinations that must not become host
+	 * connect()/sendto() targets. L4 handlers rely on this and do NOT duplicate it.
+	 * Admin REDIRECT/ENCAP targets are configured separately. */
+	if (is_forbidden_dest6(ip6->daddr)) {
+		LOG_D("Dropping IPv6 packet to forbidden destination: %s",
 		    ip6_to_string(ip6->daddr).c_str());
 		return;
 	}

--- a/nstun/net_defs.h
+++ b/nstun/net_defs.h
@@ -13,8 +13,38 @@
 #ifndef IN_LOOPBACK
 #define IN_LOOPBACK(a) ((((long int)(a)) & 0xff000000) == 0x7f000000)
 #endif
+#ifndef IN_LINKLOCAL
+#define IN_LINKLOCAL(a) ((((long int)(a)) & 0xffff0000) == 0xa9fe0000)
+#endif
+#ifndef IN_MULTICAST
+#define IN_MULTICAST(a) ((((long int)(a)) & 0xf0000000) == 0xe0000000)
+#endif
+#ifndef IN_EXPERIMENTAL
+#define IN_EXPERIMENTAL(a) ((((long int)(a)) & 0xf0000000) == 0xf0000000)
+#endif
+#ifndef IN_ZERONET
+#define IN_ZERONET(a) ((((long int)(a)) & 0xff000000) == 0x00000000)
+#endif
 
 namespace nstun {
+
+/* Guest-chosen destinations that must never become host connect()/sendto() targets.
+ * Admin REDIRECT/ENCAP targets are configured separately and are not gated here. */
+inline bool is_forbidden_dest4(uint32_t daddr_nbo) {
+	uint32_t a = ntohl(daddr_nbo);
+	return IN_LOOPBACK(a) || IN_ZERONET(a) || IN_LINKLOCAL(a) || IN_MULTICAST(a) ||
+	       IN_EXPERIMENTAL(a) || daddr_nbo == htonl(INADDR_BROADCAST);
+}
+
+inline bool is_forbidden_dest6(const uint8_t daddr[16]) {
+	const struct in6_addr* a = reinterpret_cast<const struct in6_addr*>(daddr);
+	if (IN6_IS_ADDR_LOOPBACK(a) || IN6_IS_ADDR_UNSPECIFIED(a) || IN6_IS_ADDR_V4MAPPED(a) ||
+	    IN6_IS_ADDR_V4COMPAT(a) || IN6_IS_ADDR_LINKLOCAL(a) || IN6_IS_ADDR_SITELOCAL(a) ||
+	    IN6_IS_ADDR_MULTICAST(a)) {
+		return true;
+	}
+	return false;
+}
 
 constexpr size_t NSTUN_MTU = ((1024 * 64) - 1024);
 

--- a/nstun/policy.cc
+++ b/nstun/policy.cc
@@ -35,7 +35,7 @@ RuleResult evaluate_rules4(Context* ctx, nstun_direction_t dir, nstun_proto_t pr
 		}
 		return res;
 	}
-	return {NSTUN_ACTION_ALLOW, 0, 0, false, {}}; /* Default allow */
+	return {NSTUN_ACTION_DROP, 0, 0, false, {}}; /* Default deny */
 }
 
 static bool ip6_masked_eq(const uint8_t* a, const uint8_t* b, const uint8_t* mask) {
@@ -80,7 +80,7 @@ RuleResult evaluate_rules6(Context* ctx, nstun_direction_t dir, nstun_proto_t pr
 		}
 		return res;
 	}
-	return {NSTUN_ACTION_ALLOW, 0, 0, false, {}}; /* Default allow */
+	return {NSTUN_ACTION_DROP, 0, 0, false, {}}; /* Default deny */
 }
 
 template <typename RuleMsg>

--- a/nstun/tcp.cc
+++ b/nstun/tcp.cc
@@ -337,7 +337,13 @@ bool flush_to_host(Context* ctx, TcpFlow* flow) {
 
 static void handle_socks5_init_host(Context* ctx, TcpFlow* flow, int fd) {
 	socks5_auth_reply buf;
-	ssize_t recv_len = recv(fd, &buf, sizeof(buf) - flow->proxy_rx_buffer.size(), MSG_DONTWAIT);
+	if (flow->proxy_rx_buffer.size() >= sizeof(buf)) {
+		LOG_W("SOCKS5 auth reply buffer overflow, resetting");
+		tcp_rst_and_destroy(ctx, flow);
+		return;
+	}
+	size_t remaining = sizeof(buf) - flow->proxy_rx_buffer.size();
+	ssize_t recv_len = recv(fd, &buf, remaining, MSG_DONTWAIT);
 	if (recv_len == 0) {
 		tcp_rst_and_destroy(ctx, flow);
 		return;
@@ -410,7 +416,16 @@ static void handle_socks5_connecting_host(Context* ctx, TcpFlow* flow, int fd) {
 			break; /* We have enough data */
 		}
 
-		ssize_t recv_len = recv(fd, &buf, expected_len - current_len, MSG_DONTWAIT);
+		if (expected_len > sizeof(buf)) {
+			LOG_W("SOCKS5 reply length %zu exceeds buffer, resetting", expected_len);
+			tcp_rst_and_destroy(ctx, flow);
+			return;
+		}
+		size_t want = expected_len - current_len;
+		if (want > sizeof(buf)) {
+			want = sizeof(buf);
+		}
+		ssize_t recv_len = recv(fd, &buf, want, MSG_DONTWAIT);
 		if (recv_len == 0) {
 			tcp_rst_and_destroy(ctx, flow);
 			return;

--- a/nstun/udp.cc
+++ b/nstun/udp.cc
@@ -347,6 +347,14 @@ void handle_udp4(Context* ctx, const ip4_hdr* ip, std::span<const uint8_t> paylo
 	}
 
 	const udp_hdr* udp = reinterpret_cast<const udp_hdr*>(payload.data());
+	uint16_t udp_len = ntohs(udp->len);
+	if (udp_len < sizeof(udp_hdr) || udp_len > payload.size()) {
+		LOG_D("Invalid IPv4 UDP length %u (payload %zu), dropping", udp_len, payload.size());
+		return;
+	}
+	payload = payload.first(udp_len);
+	udp = reinterpret_cast<const udp_hdr*>(payload.data());
+
 	uint16_t guest_port = ntohs(udp->source);
 	uint16_t dest_port = ntohs(udp->dest);
 
@@ -794,6 +802,14 @@ void handle_udp6(Context* ctx, const ip6_hdr* ip, std::span<const uint8_t> paylo
 	if (payload.size() < sizeof(udp_hdr)) return;
 
 	const udp_hdr* udp = reinterpret_cast<const udp_hdr*>(payload.data());
+	uint16_t udp_len = ntohs(udp->len);
+	if (udp_len < sizeof(udp_hdr) || udp_len > payload.size()) {
+		LOG_D("Invalid IPv6 UDP length %u (payload %zu), dropping", udp_len, payload.size());
+		return;
+	}
+	payload = payload.first(udp_len);
+	udp = reinterpret_cast<const udp_hdr*>(payload.data());
+
 	uint16_t guest_port = ntohs(udp->source);
 	uint16_t dest_port = ntohs(udp->dest);
 

--- a/tests/nat-ip4-only.cfg
+++ b/tests/nat-ip4-only.cfg
@@ -13,7 +13,10 @@ time_limit: 100
 
 skip_setsid: true
 
-user_net { }
+user_net {
+	rule4 { action: ALLOW }
+	rule6 { action: ALLOW }
+}
 
 mount {
 	src: "/"

--- a/tests/nat-ip6-only.cfg
+++ b/tests/nat-ip6-only.cfg
@@ -13,7 +13,10 @@ time_limit: 100
 
 skip_setsid: true
 
-user_net { }
+user_net {
+	rule4 { action: ALLOW }
+	rule6 { action: ALLOW }
+}
 
 mount {
 	src: "/"

--- a/tests/nstun.cfg
+++ b/tests/nstun.cfg
@@ -32,7 +32,8 @@ gidmap {
 
 user_net {
 	backend: NSTUN
-
+	rule4 { action: ALLOW }
+	rule6 { action: ALLOW }
 }
 
 mount {

--- a/tests/traffic-drop-tcp4.cfg
+++ b/tests/traffic-drop-tcp4.cfg
@@ -15,7 +15,10 @@ mount {
 	is_bind: true
 }
 
-user_net { }
+user_net {
+	rule4 { action: ALLOW }
+	rule6 { action: ALLOW }
+}
 
 traffic_rule {
 	proto: TCP

--- a/tests/traffic-drop-udp6.cfg
+++ b/tests/traffic-drop-udp6.cfg
@@ -15,7 +15,10 @@ mount {
 	is_bind: true
 }
 
-user_net { }
+user_net {
+	rule4 { action: ALLOW }
+	rule6 { action: ALLOW }
+}
 
 traffic_rule {
 	ip_family: IPV6

--- a/tests/traffic-mixed.cfg
+++ b/tests/traffic-mixed.cfg
@@ -16,7 +16,10 @@ mount {
 	is_bind: true
 }
 
-user_net { }
+user_net {
+	rule4 { action: ALLOW }
+	rule6 { action: ALLOW }
+}
 
 # IPv4: reject TCP port 443
 traffic_rule {

--- a/tests/traffic-rules.cfg
+++ b/tests/traffic-rules.cfg
@@ -12,7 +12,10 @@ mount {
 	is_bind: true
 }
 
-user_net { }
+user_net {
+	rule4 { action: ALLOW }
+	rule6 { action: ALLOW }
+}
 
 traffic_rule {
 	proto: TCP

--- a/util.cc
+++ b/util.cc
@@ -232,6 +232,39 @@ bool writeBufToFile(
 	return true;
 }
 
+bool sanitizeJailRelPath(const std::string& path, std::string* out) {
+	if (path.find('\0') != std::string::npos) {
+		LOG_W("Jail path contains NUL: %s", QC(path));
+		return false;
+	}
+
+	std::vector<std::string> stack;
+	for (const auto& component : strSplit(path, '/')) {
+		if (component.empty() || component == ".") {
+			continue;
+		}
+		if (component == "..") {
+			if (stack.empty()) {
+				LOG_W("Jail path escapes root via '..': %s", QC(path));
+				return false;
+			}
+			stack.pop_back();
+			continue;
+		}
+		stack.push_back(component);
+	}
+
+	/* Canonical jail path form matches existing configs ("/lib", "/tmp", "/") */
+	out->assign("/");
+	for (size_t i = 0; i < stack.size(); i++) {
+		if (i != 0) {
+			out->push_back('/');
+		}
+		out->append(stack[i]);
+	}
+	return true;
+}
+
 bool createDirRecursively(const char* dir) {
 	if (dir[0] != '/') {
 		LOG_W("The directory path must start with '/': '%s' provided", dir);
@@ -263,6 +296,17 @@ bool createDirRecursively(const char* dir) {
 		}
 		*next = '\0';
 
+		/* Refuse path-escape components even if a caller concatenates unsafely */
+		if (strcmp(curr, ".") == 0) {
+			curr = next + 1;
+			continue;
+		}
+		if (strcmp(curr, "..") == 0) {
+			LOG_W("Refusing '..' in createDirRecursively('%s')", dir);
+			close(prev_dir_fd);
+			return false;
+		}
+
 		if (mkdirat(prev_dir_fd, curr, 0755) == -1 && errno != EEXIST) {
 			if (errno != EROFS || !util::existsAsDirAt(prev_dir_fd, curr)) {
 				PLOG_W("mkdir(%s, 0755)", QC(curr));
@@ -271,9 +315,11 @@ bool createDirRecursively(const char* dir) {
 			}
 		}
 
-		int dir_fd = TEMP_FAILURE_RETRY(openat(prev_dir_fd, curr, O_DIRECTORY | O_CLOEXEC));
+		int dir_fd = TEMP_FAILURE_RETRY(
+		    openat(prev_dir_fd, curr, O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW));
 		if (dir_fd == -1) {
-			PLOG_W("openat('%d', %s, O_DIRECTORY | O_CLOEXEC)", prev_dir_fd, QC(curr));
+			PLOG_W("openat('%d', %s, O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW)",
+			    prev_dir_fd, QC(curr));
 			close(prev_dir_fd);
 			return false;
 		}

--- a/util.h
+++ b/util.h
@@ -60,6 +60,14 @@ int recvFd(int sock);
 bool writeBufToFile(
     const char* filename, const void* buf, size_t len, int open_flags, bool log_errors = true);
 bool createDirRecursively(const char* dir);
+/*
+ * Normalize a jail-relative mount destination and reject path escape.
+ * Disallows NUL and ".." components that would resolve outside the jail
+ * root (including via prefix_dst_env). Leading '/' and "." are normalized
+ * away; on success *out is a canonical absolute-within-jail path
+ * (e.g. "/lib", "/tmp/foo", or "/").
+ */
+bool sanitizeJailRelPath(const std::string& path, std::string* out);
 std::string* StrAppend(std::string* str, const char* format, ...)
     __attribute__((format(printf, 2, 3)));
 std::string StrPrintf(const char* format, ...) __attribute__((format(printf, 1, 2)));


### PR DESCRIPTION
## Summary
- Confine mount destinations under the jail root (reject `..` / path escape before `pivot_root`) and fail closed when mount isolation flags cannot be applied.
- Require capability bounding-set drops (`CAP_SETPCAP`) and treat `PR_SET_NO_NEW_PRIVS` failure as fatal unless explicitly disabled.
- Expand nstun SSRF destination denylists, validate UDP lengths / SOCKS5 recv sizing, and change unmatched nstun policy to **default-deny** (example configs that intend open networking now set explicit `ALLOW` rules).

## Test plan
- [ ] Build on Linux (`make` / Docker image)
- [ ] Confirm a crafted mount `dst` containing `..` is rejected and does not create host paths outside the staging root
- [ ] Confirm empty `user_net` with `backend: NSTUN` drops unmatched egress; configs with explicit `ALLOW` still pass traffic
- [ ] Confirm guest packets to `169.254.169.254` / multicast are dropped by the SSRF gate
- [ ] Smoke-test an example config that uses `user_net` (e.g. `tests/nstun.cfg`)