### PR TITLE
Reject mount destination path traversal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,8 @@ test: $(BIN)
 	# --- Basic sanity tests ---
 	$(call run_test, ./nsjail -q -Mo --chroot / --user 99999 --group 99999 -- /bin/true, 0)
 	$(call run_test, ./nsjail -q -Mo --chroot / --user 99999 --group 99999 -- /bin/false, 1)
+	$(call run_test, ./nsjail $(OLD_EF) -q -Mo --chroot / --user 99999 --group 99999 --tmpfsmount tmp/../escape -- /bin/true, 255)
+	$(call run_test, ./nsjail $(NEW_EF) -q -Mo --chroot / --user 99999 --group 99999 --tmpfsmount tmp/../escape -- /bin/true, 255)
 	$(call run_test, ./nsjail --config tests/seccomp.cfg -q -t 2 -- /bin/bash -c 'strace -o /dev/null /bin/true || exit 77', 77)
 	$(call run_test, ./nsjail --config tests/basic.cfg -q -t 2 -- /bin/bash -c 'strace -o /dev/null /bin/true && exit 77', 77)
 	$(call run_test, ./nsjail --config tests/pasta-nat.cfg -q -t 3 -- /bin/bash -c 'sleep 0.2; ping -W 1 -c 1 8.8.8.8 && exit 77', 77)

--- a/mnt.cc
+++ b/mnt.cc
@@ -54,6 +54,15 @@
 
 namespace mnt {
 
+bool isValidMountDestination(const std::string& path) {
+	for (const auto& component : util::strSplit(path, '/')) {
+		if (component == "..") {
+			return false;
+		}
+	}
+	return true;
+}
+
 const std::string flagsToStr(unsigned long flags) {
 	std::string res;
 

--- a/mnt.h
+++ b/mnt.h
@@ -72,6 +72,7 @@ struct mount_t {
 
 bool initNs(nsj_t* nsj);
 std::unique_ptr<std::string> findWorkDir(nsj_t* nsj, const char* purpose);
+bool isValidMountDestination(const std::string& path);
 const std::string describeMountPt(const nsjail::MountPt& mpt);
 const std::string flagsToStr(unsigned long flags);
 

--- a/mnt_legacy.cc
+++ b/mnt_legacy.cc
@@ -194,6 +194,10 @@ static bool mountWithDynamicContent(
 }
 
 static bool mountSinglePoint(mount_t* mpt, const char* newroot, const char* tmpdir) {
+	if (!mnt::isValidMountDestination(mpt->dst)) {
+		LOG_E("Invalid mount destination: %s", QC(mpt->dst));
+		return false;
+	}
 	LOG_D("Mounting (legacy): %s", mnt::describeMountPt(*mpt->mpt).c_str());
 
 	const std::string dstpath = std::string(newroot) + "/" + mpt->dst;

--- a/mnt_newapi.cc
+++ b/mnt_newapi.cc
@@ -409,6 +409,10 @@ static bool doBindMountAt(mount_t* mpt, int root_fd, const char* rel_dst) {
 }
 
 static bool mountSinglePointAt(mount_t* mpt, int root_fd) {
+	if (!mnt::isValidMountDestination(mpt->dst)) {
+		LOG_E("Invalid mount destination: %s", QC(mpt->dst));
+		return false;
+	}
 	LOG_D("Mounting (new API): %s", mnt::describeMountPt(*mpt->mpt).c_str());
 
 	const char* rel_dst = util::stripLeadingSlashes(mpt->dst.c_str());


### PR DESCRIPTION
## Summary

Reject mount destinations containing `..` path components in both the legacy and new mount APIs.

## Security impact

`MountPt.dst` is documented as the mount point inside the jail, but the legacy path-based implementation and the new `openat`-based implementation accepted traversal components. A crafted mount configuration such as `tmp/../../outside_marker` could resolve outside the jail root. With a non-mandatory `src_content` mount, this allowed a file to be written outside the root while nsjail continued successfully.

The issue was reproduced locally in a privileged container built from this repository. The same probe affected both mount implementations.

## Fix

- Add a shared mount-destination validator.
- Reject `..` components before path or mount side effects in both APIs.
- Add focused regression checks for both legacy and new mount modes.

## Validation

- Clean build with `-Wall -Wextra -Werror`.
- Pre-fix escape reproduced in both APIs.
- Post-fix escape blocked in both APIs.
- Existing true/false sanity checks continue to pass.
- `git diff --check` passes.

This change intentionally preserves existing handling of other destination components and is limited to preventing lexical path traversal.
