### PR TITLE
contain: close PR_SET_PDEATHSIG setup race

### DIFF
--- a/contain.cc
+++ b/contain.cc
@@ -26,6 +26,7 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <limits.h>
+#include <poll.h>
 #include <signal.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -94,11 +95,31 @@ static bool containDropPrivs(nsj_t* nsj) {
 	return true;
 }
 
-static bool containPrepareEnv(nsj_t* nsj) {
+bool setupParentDeathSignal(int parent_fd, pid_t expected_parent) {
 	if (prctl(PR_SET_PDEATHSIG, SIGKILL, 0, 0, 0) == -1) {
 		PLOG_E("prctl(PR_SET_PDEATHSIG, SIGKILL)");
 		return false;
 	}
+	if (parent_fd != -1) {
+		struct pollfd pfd = {.fd = parent_fd, .events = POLLIN, .revents = 0};
+		if (poll(&pfd, 1, 0) == -1) {
+			PLOG_E("poll(parent_fd=%d)", parent_fd);
+			return false;
+		}
+		if (pfd.revents & (POLLHUP | POLLERR | POLLNVAL)) {
+			LOG_E("Parent process exited before PR_SET_PDEATHSIG was installed");
+			return false;
+		}
+	} else if (getppid() != expected_parent) {
+		LOG_E("Parent process changed before PR_SET_PDEATHSIG was installed");
+		return false;
+	}
+	return true;
+}
+
+static bool containPrepareEnv(nsj_t* nsj, int parent_fd, pid_t expected_parent) {
+	/* Effective UID/GID changes clear PDEATHSIG, so restore it after containUserNs(). */
+	RETURN_ON_FAILURE(setupParentDeathSignal(parent_fd, expected_parent));
 	unsigned long personality = 0;
 	if (nsj->njc.persona_addr_compat_layout()) {
 		personality |= ADDR_COMPAT_LAYOUT;
@@ -379,7 +400,7 @@ bool setupFD(nsj_t* nsj, int fd_in, int fd_out, int fd_err) {
 	return true;
 }
 
-bool containProc(nsj_t* nsj) {
+bool containProc(nsj_t* nsj, int parent_fd, pid_t expected_parent) {
 	RETURN_ON_FAILURE(containUserNs(nsj));
 	RETURN_ON_FAILURE(containInitPidNs(nsj));
 	RETURN_ON_FAILURE(containInitMountNs(nsj));
@@ -394,7 +415,7 @@ bool containProc(nsj_t* nsj) {
 	RETURN_ON_FAILURE(containCoreSched(nsj));
 	RETURN_ON_FAILURE(containTSC(nsj));
 	RETURN_ON_FAILURE(containSetLimits(nsj));
-	RETURN_ON_FAILURE(containPrepareEnv(nsj));
+	RETURN_ON_FAILURE(containPrepareEnv(nsj, parent_fd, expected_parent));
 	RETURN_ON_FAILURE(containMakeFdsCOE(nsj));
 
 	return true;

--- a/contain.h
+++ b/contain.h
@@ -23,13 +23,15 @@
 #define NS_CONTAIN_H
 
 #include <stdbool.h>
+#include <sys/types.h>
 
 #include "nsjail.h"
 
 namespace contain {
 
 bool setupFD(nsj_t* nsj, int fd_in, int fd_out, int fd_err);
-bool containProc(nsj_t* nsj);
+bool setupParentDeathSignal(int parent_fd, pid_t expected_parent);
+bool containProc(nsj_t* nsj, int parent_fd, pid_t expected_parent);
 
 }  // namespace contain
 

--- a/subproc.cc
+++ b/subproc.cc
@@ -161,7 +161,12 @@ static const std::string concatArgs(const std::vector<const char*>& argv) {
 	return ret;
 }
 
-static void newProc(nsj_t* nsj, int netfd, int fd_in, int fd_out, int fd_err, int pipefd) {
+static void newProc(
+    nsj_t* nsj, int netfd, int fd_in, int fd_out, int fd_err, int pipefd, pid_t expected_parent) {
+	/* Arm before setup begins; containProc() re-arms after changing credentials. */
+	if (!contain::setupParentDeathSignal(pipefd, expected_parent)) {
+		return;
+	}
 	if (nsj->njc.has_oom_score_adj()) {
 		std::string score = std::to_string(nsj->njc.oom_score_adj());
 		if (!util::writeBufToFile(
@@ -206,7 +211,7 @@ static void newProc(nsj_t* nsj, int netfd, int fd_in, int fd_out, int fd_err, in
 			}
 		}
 	}
-	if (!contain::containProc(nsj)) {
+	if (!contain::containProc(nsj, pipefd, expected_parent)) {
 		return;
 	}
 	if (!nsj->njc.keep_env()) {
@@ -524,11 +529,12 @@ pid_t runChild(nsj_t* nsj, int netfd, int fd_in, int fd_out, int fd_err) {
 	flags |= (nsj->njc.clone_newtime() ? CLONE_NEWTIME : 0);
 
 	if (nsj->njc.mode() == nsjail::Mode::EXECVE) {
+		const pid_t expected_parent = getppid();
 		LOG_D("unshare(flags: %s)", cloneFlagsToStr(flags).c_str());
 		if (unshare(flags) == -1) {
 			PLOG_F("unshare(%s)", cloneFlagsToStr(flags).c_str());
 		}
-		newProc(nsj, netfd, fd_in, fd_out, fd_err, -1);
+		newProc(nsj, netfd, fd_in, fd_out, fd_err, -1, expected_parent);
 		LOG_F("Launching new process failed");
 	}
 
@@ -546,7 +552,7 @@ pid_t runChild(nsj_t* nsj, int netfd, int fd_in, int fd_out, int fd_err) {
 	pid_t pid = cloneProc(flags, SIGCHLD);
 	if (pid == 0) {
 		close(parent_fd);
-		newProc(nsj, netfd, fd_in, fd_out, fd_err, child_fd);
+		newProc(nsj, netfd, fd_in, fd_out, fd_err, child_fd, 0);
 		util::writeToFd(child_fd, &kSubprocErrorChar, sizeof(kSubprocErrorChar));
 		LOG_F("Launching child process failed");
 	}


### PR DESCRIPTION
# contain: close PR_SET_PDEATHSIG setup race

## Summary

Install the jailed child's parent-death signal before containment setup begins, and verify that the supervisor is still alive after installing it.

Clone-based modes use the existing parent/child socket as the liveness check. This works when `CLONE_NEWPID` makes the outside parent appear as PID 0 inside the child namespace. `EXECVE` mode retains a captured-parent-PID check because it has no supervisor socket.

The signal is installed a second time after user-namespace credential setup because Linux clears `PR_SET_PDEATHSIG` when effective UID or GID credentials change.

## Problem

The current signal is installed near the end of `containProc()`, after user, PID, mount, network, UTS, cgroup, capability, CPU, TSC, and rlimit setup. Linux does not deliver the parent-death signal retroactively when the parent has already exited before `PR_SET_PDEATHSIG` is called.

A deterministic local probe stopped the child immediately before the existing call and terminated only the nsjail supervisor. On the unmodified tree, the child then executed the requested workload. With this change, the same condition is detected before containment setup proceeds and the workload is not executed.

## Validation

- `make` passes with `-Wall -Wextra -Werror`.
- The repository's GitHub Actions-equivalent `docker build . --file Dockerfile` passes from a clean `make clean && make` stage.
- Standalone `/bin/true` and expected-failure `/bin/false` smoke checks pass.
- In-place `EXECVE` mode `/bin/true` passes.
- A deterministic `LD_PRELOAD` differential probe reports `BASELINE_MARKER=PRESENT` on the pinned parent and `PATCHED_MARKER=ABSENT` with this commit.
- `git diff --check` and clang-format 18 dry-run pass.

`make test` passes its first four basic/seccomp checks in Ubuntu 24.04 under WSL2, then reaches an environment-specific failure in the existing `pasta-nat` test because WSL rejects the read-only bind remount of `/etc/resolv.conf` with `EINVAL`. The same limitation is present on the unmodified baseline and is unrelated to this change.
