### PR TITLE
nstun: preserve zero-network CIDR selectors

### DIFF
--- a/nstun/policy.cc
+++ b/nstun/policy.cc
@@ -19,9 +19,9 @@ RuleResult evaluate_rules4(Context* ctx, nstun_direction_t dir, nstun_proto_t pr
 		if (r.direction != dir) continue;
 		if (r.proto != NSTUN_PROTO_ANY && r.proto != proto) continue;
 
-		if (r.src_ip4 != 0 && (src_ip4 & r.src_mask4) != (r.src_ip4 & r.src_mask4))
+		if (r.src_mask4 != 0 && (src_ip4 & r.src_mask4) != (r.src_ip4 & r.src_mask4))
 			continue;
-		if (r.dst_ip4 != 0 && (dst_ip4 & r.dst_mask4) != (r.dst_ip4 & r.dst_mask4))
+		if (r.dst_mask4 != 0 && (dst_ip4 & r.dst_mask4) != (r.dst_ip4 & r.dst_mask4))
 			continue;
 
 		if (r.sport_start != 0 && (sport < r.sport_start || sport > r.sport_end)) continue;
@@ -59,9 +59,9 @@ RuleResult evaluate_rules6(Context* ctx, nstun_direction_t dir, nstun_proto_t pr
 		if (r.direction != dir) continue;
 		if (r.proto != NSTUN_PROTO_ANY && r.proto != proto) continue;
 
-		if (!ip6_is_zero(r.src_ip6) && !ip6_masked_eq(src_ip6, r.src_ip6, r.src_mask6))
+		if (!ip6_is_zero(r.src_mask6) && !ip6_masked_eq(src_ip6, r.src_ip6, r.src_mask6))
 			continue;
-		if (!ip6_is_zero(r.dst_ip6) && !ip6_masked_eq(dst_ip6, r.dst_ip6, r.dst_mask6))
+		if (!ip6_is_zero(r.dst_mask6) && !ip6_masked_eq(dst_ip6, r.dst_ip6, r.dst_mask6))
 			continue;
 
 		if (r.sport_start != 0 && (sport < r.sport_start || sport > r.sport_end)) continue;


### PR DESCRIPTION
## Summary

NSTUN used the stored IP address value to determine whether an
`src_ip` or `dst_ip` selector was present in a policy rule.

This makes valid CIDR selectors whose network address is zero, such as
`0.0.0.0/1` or `::/1`, indistinguishable from an unspecified selector.

For example:

```text
direction: GUEST_TO_HOST
action: ALLOW
dst_ip: 0.0.0.0/1
```

was effectively evaluated without the `dst_ip` restriction, so
destinations outside that network could match the rule instead of
falling through to a later `DROP`.

Use the parsed mask rather than the address value to determine whether
an IP selector restricts matching. A zero mask corresponds to an
unrestricted `/0`, which has the same matching semantics as an omitted
selector.

## Testing

The project builds successfully with:

```bash
make
```

Local before/after testing covered both IPv4 and IPv6.

For IPv4, rules using `0.0.0.0/1`, `0.0.0.0/2`, and `0.0.0.0/4`
incorrectly allowed destinations outside their respective networks
before this change. After the change, destinations inside the selected
CIDR continue to connect while destinations outside it fall through to
`DROP`.

The same behavior was reproduced with an IPv6 `::/1` destination
selector: an address outside `::/1` was accepted before the change and
blocked afterward.

A source selector was also tested with `src_ip: 0.0.0.0/1`. A source
outside the selected CIDR matched the rule before the change, while
after the change the connection was dropped by policy.