### PR TITLE
nstun: reject out-of-range port values

### DIFF
--- a/nstun/policy.cc
+++ b/nstun/policy.cc
@@ -124,6 +124,15 @@ RuleParseStatus fill_rule_common(const RuleMsg& r, nstun_rule_t* nr) {
 		nr->proto = NSTUN_PROTO_ANY;
 	}
 
+	if ((r.has_sport() && r.sport() > UINT16_MAX) ||
+	    (r.has_sport_end() && r.sport_end() > UINT16_MAX) ||
+	    (r.has_dport() && r.dport() > UINT16_MAX) ||
+	    (r.has_dport_end() && r.dport_end() > UINT16_MAX) ||
+	    (r.has_redirect_port() && r.redirect_port() > UINT16_MAX)) {
+		LOG_E("NSTUN rule contains a port outside the valid range");
+		return RuleParseStatus::ABORT;
+	}
+
 	nr->sport_start = r.has_sport() ? r.sport() : 0;
 	nr->sport_end = r.has_sport_end() ? r.sport_end() : nr->sport_start;
 


### PR DESCRIPTION
## Summary

NSTUN policy ports are represented as `uint32` values in the
configuration protobuf but stored as `uint16_t` values internally.

The values were previously assigned without range validation, allowing
ports greater than 65535 to be silently truncated before policy
evaluation.

For example, a rule containing:

```text
direction: GUEST_TO_HOST
action: ALLOW
proto: TCP
dport: 65536
```

stored `dport` as zero. Since zero is used internally to represent an
unspecified port selector, the rule was evaluated without its intended
destination-port restriction.

Other out-of-range values can wrap to a different valid port. For
example, `83646` truncates to `18110`.

Reject port values that cannot be represented by the internal
`uint16_t` fields before storing the rule.

The validation covers `sport`, `sport_end`, `dport`, `dport_end`, and
`redirect_port`.

## Testing

The project builds successfully with:

```bash
make
```

Local before/after testing used a TCP service on port 18110.

Before this change:

- `dport: 18111` correctly blocked access to port 18110;
- `dport: 65536` incorrectly allowed access to port 18110 because the
  value truncated to zero and disabled the port selector;
- `dport: 83646` incorrectly allowed access to port 18110 because the
  value truncated to 18110.

After this change, both out-of-range configurations are rejected during
NSTUN initialization.

Boundary testing also verified that `65535` remains accepted while
`65536` is rejected.