### PR TITLE
nstun: fail closed for proxy actions matched by ICMP

### DIFF
--- a/nstun/icmp.cc
+++ b/nstun/icmp.cc
@@ -178,6 +178,10 @@ void handle_icmp6(Context* ctx, const ip6_hdr* ip, std::span<const uint8_t> payl
 		if (rule.action == NSTUN_ACTION_DROP) {
 			LOG_D("ICMPv6 dropped by policy");
 			return;
+		} else if (rule.action == NSTUN_ACTION_ENCAP_SOCKS5 ||
+		           rule.action == NSTUN_ACTION_ENCAP_CONNECT) {
+			LOG_D("Proxy encapsulation is not supported for ICMPv6, dropping");
+			return;
 		} else if (rule.action == NSTUN_ACTION_REJECT) {
 			LOG_D("ICMPv6 rejected by policy");
 			send_icmp6_error(ctx, ip, sizeof(ip6_hdr) + payload.size(),
@@ -297,6 +301,10 @@ void handle_icmp4(Context* ctx, const ip4_hdr* ip, std::span<const uint8_t> payl
 
 		if (rule.action == NSTUN_ACTION_DROP) {
 			LOG_D("ICMP dropped by policy");
+			return;
+		} else if (rule.action == NSTUN_ACTION_ENCAP_SOCKS5 ||
+		           rule.action == NSTUN_ACTION_ENCAP_CONNECT) {
+			LOG_D("Proxy encapsulation is not supported for ICMP, dropping");
 			return;
 		} else if (rule.action == NSTUN_ACTION_REJECT) {
 			LOG_D("ICMP rejected by policy");


### PR DESCRIPTION
## Summary

NSTUN proxy rules reject `ENCAP_SOCKS5` and `ENCAP_CONNECT` when the configured protocol is explicitly `ICMP`.

However, `ANY` rules also match ICMP traffic. A proxy rule using `proto: ANY` therefore reaches the ICMP handlers with an `ENCAP_*` action.

The ICMP handlers only handled `DROP` and `REJECT` specially. Proxy actions continued through the normal ICMP forwarding path, causing the packet to be sent directly to its original destination instead of through the configured proxy.

For example:

```text
rule6 {
  direction: GUEST_TO_HOST
  proto: ANY
  action: ENCAP_CONNECT
  redirect_ip: "127.0.0.1"
  redirect_port: 3128
}
```

This change makes the ICMPv4 and ICMPv6 handlers fail closed when they receive either proxy action.

## Reproduction

Reproduced on parent commit:

`5ebcc30bef4af60d6e28f012dd8bf7b99b8b0acf`

A controlled IPv6 destination was configured locally as `2001:db8:306::1`.

### Control

With:

```text
proto: ANY
action: DROP
```

NSTUN logged:

```text
ICMPv6 dropped by policy
```

and ping reported:

```text
1 packets transmitted, 0 received, 100% packet loss
```

### Proxy rule before the fix

With:

```text
proto: ANY
action: ENCAP_CONNECT
redirect_ip: "127.0.0.1"
redirect_port: 3128
```

NSTUN logged:

```text
Created IPv6 ICMP flow for ID 1
```

and the destination was reached successfully:

```text
64 bytes from 2001:db8:306::1
1 packets transmitted, 1 received, 0% packet loss
```

A listener on the configured proxy endpoint saw no connection.

For comparison, configuring the same proxy action with explicit `proto: ICMP` is rejected during rule parsing:

```text
Proxy encapsulation is not supported for ICMP/ICMPv6
```

This demonstrates that `ANY` bypasses the existing protocol/action validation and reaches a forwarding path that does not implement proxy encapsulation.

## Testing

The project builds successfully:

```text
make -j2
BUILD_RC=0
```

After the fix, the same `ANY + ENCAP_CONNECT` test logs:

```text
Proxy encapsulation is not supported for ICMPv6, dropping
1 packets transmitted, 0 received, 100% packet loss
```

The same fail-closed behavior was verified for `ANY + ENCAP_SOCKS5`.

TCP and UDP proxy handling are unchanged.
