### PR TITLE
contain: fail closed when no_new_privs cannot be enabled

### DIFF
--- a/contain.cc
+++ b/contain.cc
@@ -83,7 +83,8 @@ static bool containDropPrivs(nsj_t* nsj) {
 	if (!nsj->njc.disable_no_new_privs()) {
 		if (prctl(PR_SET_NO_NEW_PRIVS, 1UL, 0UL, 0UL, 0UL) == -1) {
 			/* Only new kernels support it */
-			PLOG_W("prctl(PR_SET_NO_NEW_PRIVS, 1)");
+			PLOG_E("prctl(PR_SET_NO_NEW_PRIVS, 1)");
+			return false;
 		}
 	}
 


### PR DESCRIPTION
## Summary

- abort jail setup when PR_SET_NO_NEW_PRIVS is expected but cannot be enabled
- keep the explicit --disable_no_new_privs escape hatch unchanged

## Security rationale

NsJail enables 
o_new_privs by default so the jailed process cannot gain additional privileges across execve through mechanisms such as setuid/setgid bits or file capabilities. The current containDropPrivs() path only logs a warning if PR_SET_NO_NEW_PRIVS fails and then continues containment, so an unexpected failure silently weakens that guarantee.

This also restores the original fail-closed behavior. Before #8, failure to set PR_SET_NO_NEW_PRIVS returned alse. PR #8 added the explicit --disable_no_new_privs option (documented as dangerous), but the same change removed that failure return. The explicit opt-out is sufficient for callers that intentionally need to skip the protection; an unexpected failure should not act as a second implicit opt-out.

## Validation

I used a deterministic fault-injection harness around the exact containDropPrivs() control flow:

| Case | Current | Patched |
| --- | --- | --- |
| default, PR_SET_NO_NEW_PRIVS returns EPERM | continues (	rue) | aborts (alse) |
| explicit --disable_no_new_privs | continues | continues |
| normal successful prctl | continues | continues |

git diff --check is clean. The change is intentionally limited to the failure path; full-project build/CI is left to the repository checks because my local environment does not currently have the complete NsJail build dependency set.