### PR TITLE
unotify: emit syscall numbers in the generated policy, and trace 11 missing path syscalls

### DIFF
--- a/unotify/syscall_defs.h
+++ b/unotify/syscall_defs.h
@@ -241,12 +241,20 @@ constexpr size_t kTracedSyscallCount = sizeof(kTracedSyscalls) / sizeof(kTracedS
 /*
  * Build the kafel policy string from the table.
  * Called by sandbox.cc - no manual syscall list maintenance needed.
+ *
+ * The syscall number is used rather than the name. kafel resolves names from a
+ * per-architecture table, and those tables are not equally complete, so a name
+ * that resolves on one architecture can be unknown on another; kafel_compile()
+ * then fails and nsjail does not start at all. The number is a compile time
+ * constant of the architecture being built for. The name is kept as a comment
+ * so the generated policy stays readable.
  */
 inline std::string buildKafelPolicy() {
 	std::string p = "POLICY unotify {\n  USER_NOTIF {\n";
 	for (size_t i = 0; i < kTracedSyscallCount; i++) {
 		if (i > 0) p += ", ";
-		p += kTracedSyscalls[i].kafel_name;
+		p += "SYSCALL[" + std::to_string(kTracedSyscalls[i].nr) + "] /* " +
+		     kTracedSyscalls[i].kafel_name + " */";
 	}
 	p += "\n  }\n}\nUSE unotify DEFAULT ALLOW\n";
 	return p;

--- a/unotify/syscall_defs.h
+++ b/unotify/syscall_defs.h
@@ -76,6 +76,11 @@ static constexpr SyscallDef kTracedSyscalls[] = {
 	{__NR_lstat, "newlstat", "lstat", SyscallCategory::FS,
 	    {A::PATH, A::SKIP, A::SKIP, A::SKIP, A::SKIP, A::SKIP}},
 #endif /* __NR_lstat */
+	/* statfs(path, buf) reads filesystem state through a path, like stat above. */
+#ifdef __NR_statfs
+	{__NR_statfs, "statfs", "statfs", SyscallCategory::FS,
+	    {A::PATH, A::SKIP, A::SKIP, A::SKIP, A::SKIP, A::SKIP}},
+#endif /* __NR_statfs */
 #ifdef __NR_access
 	{__NR_access, "access", "access", SyscallCategory::FS,
 	    {A::PATH, A::ACCESS, A::SKIP, A::SKIP, A::SKIP, A::SKIP}},
@@ -92,6 +97,14 @@ static constexpr SyscallDef kTracedSyscalls[] = {
 	{__NR_lchown, "lchown", "lchown", SyscallCategory::FS,
 	    {A::PATH, A::UID, A::GID, A::SKIP, A::SKIP, A::SKIP}},
 #endif /* __NR_lchown */
+	/*
+	 * truncate(path, length) writes to a file without opening it, so without
+	 * this entry the content change is not observed at all.
+	 */
+#ifdef __NR_truncate
+	{__NR_truncate, "truncate", "truncate", SyscallCategory::FS,
+	    {A::PATH, A::SKIP, A::SKIP, A::SKIP, A::SKIP, A::SKIP}},
+#endif /* __NR_truncate */
 #ifdef __NR_readlink
 	{__NR_readlink, "readlink", "readlink", SyscallCategory::FS,
 	    {A::PATH, A::SKIP, A::SKIP, A::SKIP, A::SKIP, A::SKIP}},
@@ -125,6 +138,45 @@ static constexpr SyscallDef kTracedSyscalls[] = {
 	    {A::PATH, A::SKIP, A::SKIP, A::SKIP, A::SKIP, A::SKIP}},
 #endif /* __NR_chroot */
 
+	/*
+	 * Extended attributes are file metadata addressed by path, like chmod and
+	 * chown above. setxattr and removexattr modify a file, getxattr and
+	 * listxattr read it. The l* variants do not follow symlinks, the same
+	 * distinction as stat and lstat.
+	 */
+#ifdef __NR_setxattr
+	{__NR_setxattr, "setxattr", "setxattr", SyscallCategory::FS,
+	    {A::PATH, A::SKIP, A::SKIP, A::SKIP, A::SKIP, A::SKIP}},
+#endif /* __NR_setxattr */
+#ifdef __NR_lsetxattr
+	{__NR_lsetxattr, "lsetxattr", "lsetxattr", SyscallCategory::FS,
+	    {A::PATH, A::SKIP, A::SKIP, A::SKIP, A::SKIP, A::SKIP}},
+#endif /* __NR_lsetxattr */
+#ifdef __NR_getxattr
+	{__NR_getxattr, "getxattr", "getxattr", SyscallCategory::FS,
+	    {A::PATH, A::SKIP, A::SKIP, A::SKIP, A::SKIP, A::SKIP}},
+#endif /* __NR_getxattr */
+#ifdef __NR_lgetxattr
+	{__NR_lgetxattr, "lgetxattr", "lgetxattr", SyscallCategory::FS,
+	    {A::PATH, A::SKIP, A::SKIP, A::SKIP, A::SKIP, A::SKIP}},
+#endif /* __NR_lgetxattr */
+#ifdef __NR_listxattr
+	{__NR_listxattr, "listxattr", "listxattr", SyscallCategory::FS,
+	    {A::PATH, A::SKIP, A::SKIP, A::SKIP, A::SKIP, A::SKIP}},
+#endif /* __NR_listxattr */
+#ifdef __NR_llistxattr
+	{__NR_llistxattr, "llistxattr", "llistxattr", SyscallCategory::FS,
+	    {A::PATH, A::SKIP, A::SKIP, A::SKIP, A::SKIP, A::SKIP}},
+#endif /* __NR_llistxattr */
+#ifdef __NR_removexattr
+	{__NR_removexattr, "removexattr", "removexattr", SyscallCategory::FS,
+	    {A::PATH, A::SKIP, A::SKIP, A::SKIP, A::SKIP, A::SKIP}},
+#endif /* __NR_removexattr */
+#ifdef __NR_lremovexattr
+	{__NR_lremovexattr, "lremovexattr", "lremovexattr", SyscallCategory::FS,
+	    {A::PATH, A::SKIP, A::SKIP, A::SKIP, A::SKIP, A::SKIP}},
+#endif /* __NR_lremovexattr */
+
 	/* FS - arg0 = dirfd, arg1 = path */
 #ifdef __NR_openat
 	{__NR_openat, "openat", "openat", SyscallCategory::FS,
@@ -152,6 +204,16 @@ static constexpr SyscallDef kTracedSyscalls[] = {
 	{__NR_faccessat, "faccessat", "faccessat", SyscallCategory::FS,
 	    {A::DIRFD, A::PATH, A::ACCESS, A::SKIP, A::SKIP, A::SKIP}},
 #endif /* __NR_faccessat */
+	/*
+	 * faccessat2(dirfd, path, mode, flags) is what glibc's faccessat() uses on
+	 * modern kernels; it only falls back to faccessat when the kernel lacks it.
+	 * Without this entry an access check made through glibc's faccessat() is
+	 * never observed; a plain access(2) is still traced by its own entry.
+	 */
+#ifdef __NR_faccessat2
+	{__NR_faccessat2, "faccessat2", "faccessat2", SyscallCategory::FS,
+	    {A::DIRFD, A::PATH, A::ACCESS, A::SKIP, A::SKIP, A::SKIP}},
+#endif /* __NR_faccessat2 */
 #ifdef __NR_fchmodat
 	{__NR_fchmodat, "fchmodat", "fchmodat", SyscallCategory::FS,
 	    {A::DIRFD, A::PATH, A::OCTAL, A::SKIP, A::SKIP, A::SKIP}},


### PR DESCRIPTION
Two commits on top of 5ebcc30. The second adds 11 entries to `kTracedSyscalls`; the
first is a defect I ran into while preparing it.

`--seccomp_unotify` does not start on i386 or arm today. The generated kafel policy
names its syscalls, kafel resolves names from a per-architecture table, and those
tables are not equally complete: `openat2` is unknown to kafel on both targets and
`statx` on arm. `kafel_compile()` then fails and nsjail exits 255 before running
anything. Emitting the syscall number instead removes the dependency; the name stays
in the policy as a comment.

The second commit adds path based syscalls the trace table misses, so that
truncating a file, reading or writing an extended attribute, and checking access
through modern glibc stop going unreported. Each one is backed by a run in which the
file demonstrably changed and the report did not say so. It is also why the first
commit comes first: without it, adding `faccessat2` would put a third name into the
same position on i386 and arm.

Tracing costs about 88 us per call in my build, so the additions are not free. The
Cost section has the numbers and the control, including the one case where they are
larger than I first assumed.

The two commits are separable. If you want only one of them, say so and I will split.

## 1. The generated policy depends on kafel's per-architecture name table

`buildKafelPolicy()` lists the `kafel_name` of every table entry. When a name does
not resolve, `kafel_compile()` fails, `preparePolicy()` returns false, and nsjail
does not start. Reproduced on amd64 by replacing one `kafel_name` with a name kafel
does not know:

```
[E] preparePolicy():160 Could not compile the default unotify seccomp policy:
    3:118: Undefined identifier `no_such_syscall'
[F] main():386 Couldn't prepare sandboxing policy
exit 255
```

No report file is written; the process never runs. Two entries are in that position
today. Checked by taking `__NR_` from the cross compiler for each target and looking
each `kafel_name` up in that target's kafel table, counting only the entries the
`#ifdef` keeps:

| target | kept | skipped | unknown to kafel |
|---|---|---|---|
| amd64 | 38 | 0 | none |
| aarch64 | 23 | 15 | none |
| riscv64 | 22 | 16 | none |
| i386 | 37 | 1 | `openat2` |
| arm | 37 | 1 | `openat2`, `statx` |

`openat2` has been in the table since ee2d05e and `statx` since c20246a.
`debian/control` says `Architecture: any`, so i386 and armhf are built. m68k and the
mips targets I could not check, no cross compiler at hand, and I have not run nsjail
on i386 or arm; the failure above is the amd64 reproduction of the same mechanism.

The syscall number is a compile time constant of the architecture being built for.
kafel accepts `SYSCALL[<nr>]` (parser.y) and C style comments (lexer.l), so the name
stays in the generated policy and it remains readable. Measured on amd64 with one
workload and a fresh build per form: the name based policy, the numeric one, and the
numeric one with the comment produce identical syscall distributions in the report.
With the numeric form a `kafel_name` kafel does not know no longer prevents startup,
and the syscall is still reported under its `display_name`.

## 2. Path based syscalls the table misses

Since the policy ends in `DEFAULT ALLOW`, a syscall that is not in the table is never
intercepted and never reaches the report. Each case below ran under
`--seccomp_unotify` through the glibc wrappers rather than raw syscall numbers, on
one file and a symlink to it. The right column is what the report attributed to that
path:

| what ran inside the jail | what the report attributed |
|---|---|
| `truncate(p, 3)`; the file was 21 bytes before and 3 after, measured from outside the jail | `access`, `newfstatat`, `openat`, nothing else |
| `setfattr -n user.probe -v x p`; the attribute was still set after the run, checked from outside | one `newfstatat`, nothing else |
| `faccessat(AT_FDCWD, p, F_OK, AT_EACCESS)` | nothing, and no `faccessat` either |
| `statfs(p, &buf)` | nothing |
| `lsetxattr`, `lgetxattr`, `llistxattr`, `lremovexattr` on the symlink | nothing |

`faccessat2` is the same case as the `statx` entry in c20246a: modern glibc reaches
for it first and only falls back to the traced `faccessat` on older kernels. A plain
`access(2)` is still traced by its own entry; what goes unseen is the check made
through `faccessat()`. That no `faccessat` line appears above is what shows which of
the two glibc issued.

`truncate` changes a file's contents without opening it. It gets its own `fs_access`
block with no `mode`, because `mode` is part of the map key in `record.h`, so nothing
in the report marks that path as written.

The `l*` variants are listed separately, the same way `stat` and `lstat` are. They
are exercised through a symlink, so all 11 entries are covered by the measurement.
Their return values there are `EPERM` and `ENODATA`, since `user.*` attributes are
not allowed on symlinks; what is measured is whether the call reaches the report.

The flags argument of `faccessat2` is left undecoded, the same as every other `AT_*`
entry in the table.

**What this is not.** The unotify thread answers every notification with
`SECCOMP_USER_NOTIF_FLAG_CONTINUE`, so none of this is an escape or a bypass of
enforcement. It is only about what the report shows.

**Left out on purpose.** The same sweep found `creat`, the timestamp family (`utime`,
`utimes`, `utimensat`, `futimesat`) and the privileged mount and accounting calls
(`mount`, `umount2`, `pivot_root`, `swapon`, `swapoff`, `acct`, `quotactl`,
`name_to_handle_at`, `inotify_add_watch`) outside the table as well. `creat` is
another path based content write, and the timestamp family is the closest remaining
sibling of the traced `chmod` and `chown`. I kept this commit to the calls I ran, and
I am glad to add either group here or in a follow-up, whichever you prefer.

## Cost

Tracing is not free. Measured with the same binary and the same workload, once with
`--seccomp_unotify` and once without, 7 runs each, median:

| workload | traced | untraced | traced calls | per call |
|---|---|---|---|---|
| `find /usr/include -type f -readable` | 263 ms | 13 ms | 2816 | 88 us |
| `grep -rl` over the same tree | 451 ms | 36 ms | 2809 | 147 us |

The first is dominated by 2523 `faccessat2` calls, the second by 2665 `openat`, which
the table already traces. A traced access check is therefore not more expensive than
a traced open; what changes is that these checks used to be invisible and so cost
nothing.

I first assumed the other 10 entries would not show up in ordinary work. That is
wrong, and the xattr group is the larger cost, not `faccessat2`: in the same image,
`ls -l /usr/bin` issues 440 `lgetxattr` and 347 `getxattr` calls, because it checks
each entry for a security context and an ACL. Plain `ls` and `cp -a` issue none. If
either group is unwelcome at that price I am glad to drop it; the xattr entries and
`faccessat2` are independent of each other.

## Checks

Built with `make clean && make` in the Dockerfile's base image, pinned by digest, with
the `-Wall -Wextra -Werror` the Makefile sets. `make test` was run in both states with
a fresh build each: 4 checks pass and the run stops at the 5th, `tests/pasta-nat.cfg`,
identically before and after, and the passing lines are the same by diff. The `test`
target holds 61 `run_test` calls in this configuration; the other 56 do not execute,
because `run_test` exits on the first failure. `tests/pasta-nat.cfg` pings 8.8.8.8
through pasta and does not pass in this container. None of the checks in the target
exercise `--seccomp_unotify`.

`clang-format` is not applied to this file. `make indent` runs it over
`$(SRCS_CXX:.cc=.h)`, `macros.h`, `$(SRCS_CXX)`, `$(SRCS_PROTO)` and `configs/*.json`;
`unotify/syscall_defs.h` has no matching `.cc` and is in none of those lists. Of the
32 headers the target does cover, 31 are clang-format clean, while every header
outside it deviates. The new entries therefore follow the style of the surrounding
table.
