### PR TITLE
mnt: decode escaped mountinfo paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ endif
 
 BIN = nsjail
 LIBS = kafel/libkafel.a
-TEST_BINS = tests/nstun_buffer_budget_test tests/nstun_policy_test tests/nstun_ip_test
+TEST_BINS = tests/mountinfo_path_test tests/nstun_buffer_budget_test tests/nstun_policy_test tests/nstun_ip_test
 
 # If PASTA_BIN_PATH is not provided in env, dynamically search for it if EMBED_PASTA is requested
 # or fallback to it naturally.
@@ -62,7 +62,7 @@ ifneq ($(PASTA_BIN_PATH),)
 	CXXFLAGS += -DPASTA_BIN_PATH='"$(PASTA_BIN_PATH)"'
 endif
 
-SRCS_CXX = caps.cc cgroup.cc cgroup2.cc cmdline.cc config.cc contain.cc cpu.cc logs.cc mnt.cc mnt_legacy.cc mnt_newapi.cc net.cc nsjail.cc pid.cc sandbox.cc subproc.cc uts.cc user.cc unotify/unotify.cc unotify/stats.cc unotify/syscall.cc util.cc nstun/nstun.cc nstun/policy.cc nstun/encap.cc nstun/iface.cc nstun/tun.cc nstun/ip.cc nstun/icmp.cc nstun/udp.cc nstun/tcp.cc
+SRCS_CXX = caps.cc cgroup.cc cgroup2.cc cmdline.cc config.cc contain.cc cpu.cc logs.cc mountinfo.cc mnt.cc mnt_legacy.cc mnt_newapi.cc net.cc nsjail.cc pid.cc sandbox.cc subproc.cc uts.cc user.cc unotify/unotify.cc unotify/stats.cc unotify/syscall.cc util.cc nstun/nstun.cc nstun/policy.cc nstun/encap.cc nstun/iface.cc nstun/tun.cc nstun/ip.cc nstun/icmp.cc nstun/udp.cc nstun/tcp.cc
 SRCS_PROTO = config.proto unotify/unotify.proto
 
 SRCS_PB_CXX = $(SRCS_PROTO:.proto=.pb.cc)
@@ -161,6 +161,7 @@ test-cmdline: $(BIN)
 
 .PHONY: test
 test: $(BIN) $(TEST_BINS) test-cmdline
+	$(call run_test, ./tests/mountinfo_path_test, 0)
 	$(call run_test, ./tests/nstun_buffer_budget_test, 0)
 	$(call run_test, ./tests/nstun_policy_test, 0)
 	$(call run_test, ./tests/nstun_ip_test, 0)
@@ -263,6 +264,9 @@ endif
 tests/nstun_buffer_budget_test: tests/nstun_buffer_budget_test.cc nstun/buffer_budget.h
 	$(CXX) $(filter-out -c,$(CXXFLAGS)) $< -o $@
 
+tests/mountinfo_path_test: tests/mountinfo_path_test.cc mountinfo.cc mountinfo.h
+	$(CXX) $(filter-out -c,$(CXXFLAGS)) tests/mountinfo_path_test.cc mountinfo.cc -o $@
+
 tests/nstun_policy_test: tests/nstun_policy_test.cc nstun/policy.cc logs.cc util.cc $(SRCS_PB_CXX)
 	$(CXX) $(filter-out -c,$(CXXFLAGS)) tests/nstun_policy_test.cc nstun/policy.cc logs.cc util.cc $(SRCS_PB_CXX) -o $@ $(LDFLAGS)
 
@@ -286,7 +290,9 @@ cpu.o: cpu.h nsjail.h config.pb.h logs.h util.h
 logs.o: logs.h macros.h util.h nsjail.h config.pb.h
 mnt.o: mnt.h nsjail.h config.pb.h logs.h macros.h mnt_legacy.h mnt_newapi.h
 mnt.o: subproc.h util.h
-mnt_legacy.o: mnt_legacy.h mnt.h nsjail.h config.pb.h logs.h macros.h util.h
+mountinfo.o: mountinfo.h
+mnt_legacy.o: mnt_legacy.h mnt.h nsjail.h config.pb.h logs.h macros.h
+mnt_legacy.o: mountinfo.h util.h
 mnt_newapi.o: mnt_newapi.h mnt.h nsjail.h config.pb.h logs.h util.h
 net.o: net.h nsjail.h config.pb.h logs.h macros.h nstun/nstun.h util.h
 nsjail.o: nsjail.h config.pb.h cgroup2.h cmdline.h logs.h macros.h net.h

--- a/mnt_legacy.cc
+++ b/mnt_legacy.cc
@@ -38,6 +38,7 @@
 
 #include "logs.h"
 #include "macros.h"
+#include "mountinfo.h"
 #include "mnt.h"
 #include "util.h"
 
@@ -338,7 +339,12 @@ bool remountPt(mnt::mount_t& mpt) {
 				if (endp == nullptr) {
 					continue;
 				}
-				std::string mp(p, endp - p);
+				std::string mp;
+				if (!mountinfo::decodePath(std::string_view(p, endp - p), &mp)) {
+					LOG_W(
+					    "Invalid escaped mount point in /proc/self/mountinfo");
+					continue;
+				}
 				if (mp != mpt.dst && mp.compare(0, prefix.size(), prefix) == 0) {
 					/* best-effort; remountOne logs any submount it can't
 					 * re-flag */

--- a/mountinfo.cc
+++ b/mountinfo.cc
@@ -1,0 +1,36 @@
+#include "mountinfo.h"
+
+namespace mountinfo {
+
+bool decodePath(std::string_view encoded, std::string* decoded) {
+	decoded->clear();
+	decoded->reserve(encoded.size());
+
+	for (size_t i = 0; i < encoded.size();) {
+		if (encoded[i] != '\\') {
+			decoded->push_back(encoded[i++]);
+			continue;
+		}
+
+		if (i + 3 >= encoded.size()) {
+			return false;
+		}
+		unsigned value = 0;
+		for (size_t j = 1; j <= 3; ++j) {
+			const char digit = encoded[i + j];
+			if (digit < '0' || digit > '7') {
+				return false;
+			}
+			value = (value << 3) | static_cast<unsigned>(digit - '0');
+		}
+		if (value == 0 || value > 0xff) {
+			return false;
+		}
+		decoded->push_back(static_cast<char>(value));
+		i += 4;
+	}
+
+	return true;
+}
+
+}  // namespace mountinfo

--- a/mountinfo.h
+++ b/mountinfo.h
@@ -1,0 +1,13 @@
+#ifndef NS_MOUNTINFO_H
+#define NS_MOUNTINFO_H
+
+#include <string>
+#include <string_view>
+
+namespace mountinfo {
+
+bool decodePath(std::string_view encoded, std::string* decoded);
+
+}  // namespace mountinfo
+
+#endif /* NS_MOUNTINFO_H */

--- a/tests/mountinfo_path_test.cc
+++ b/tests/mountinfo_path_test.cc
@@ -1,0 +1,41 @@
+#include <cstdio>
+#include <string>
+
+#include "mountinfo.h"
+
+static bool expectDecode(const char* encoded, const std::string& expected) {
+	std::string decoded;
+	if (!mountinfo::decodePath(encoded, &decoded)) {
+		fprintf(stderr, "decodePath unexpectedly rejected '%s'\n", encoded);
+		return false;
+	}
+	if (decoded != expected) {
+		fprintf(stderr, "decodePath('%s') produced an unexpected path\n", encoded);
+		return false;
+	}
+	return true;
+}
+
+static bool expectReject(const char* encoded) {
+	std::string decoded;
+	if (mountinfo::decodePath(encoded, &decoded)) {
+		fprintf(stderr, "decodePath unexpectedly accepted '%s'\n", encoded);
+		return false;
+	}
+	return true;
+}
+
+int main() {
+	if (!expectDecode("/mnt/plain/sub", "/mnt/plain/sub")) return 1;
+	if (!expectDecode("/mnt/has\\040space/sub", "/mnt/has space/sub")) return 1;
+	if (!expectDecode("/mnt/has\\011tab", "/mnt/has\ttab")) return 1;
+	if (!expectDecode("/mnt/has\\012newline", "/mnt/has\nnewline")) return 1;
+	if (!expectDecode("/mnt/has\\134backslash", "/mnt/has\\backslash")) return 1;
+	if (!expectDecode("/mnt/a\\040b\\134c", "/mnt/a b\\c")) return 1;
+
+	if (!expectReject("/mnt/truncated\\04")) return 1;
+	if (!expectReject("/mnt/non-octal\\xyz")) return 1;
+	if (!expectReject("/mnt/nul\\000suffix")) return 1;
+
+	return 0;
+}


### PR DESCRIPTION
## Summary

The legacy recursive-remount pass added in #284 reads mount points from `/proc/self/mountinfo`, but field 5 uses three-digit octal escapes for spaces, tabs, newlines, and backslashes. Comparing the encoded field directly with the real mount destination skips nested mounts when the destination contains one of those characters.

As a result, a nested mount can retain `suid`, `dev`, and `exec` behavior even when the bind requests `nosuid`, `nodev`, and `noexec`.

Decode mountinfo paths before the existing prefix comparison and remount. The rest of the best-effort remount behavior remains unchanged.

## Verification

- Added a focused parser test for all four kernel escape forms, combined escapes, and malformed input.
- Full Linux Docker build passes with the repository's `-Wall -Wextra -Werror` flags.
- Reproduced on unmodified `44e08fd`: a nested executable under `/space dst` ran and the nested mount lacked `nosuid,nodev,noexec`.
- With this patch, the same mount shows `nosuid,nodev,noexec` and execution fails with `EACCES`.
