### PR TITLE
mnt: fail closed when recursive mount restrictions cannot be applied

### DIFF
--- a/mnt_legacy.cc
+++ b/mnt_legacy.cc
@@ -316,37 +316,44 @@ bool remountPt(mnt::mount_t& mpt) {
 	 * recursive read-only pass and the new-mount-API backend, which applies the
 	 * attributes with mount_setattr(AT_RECURSIVE).
 	 */
-	if (mpt.flags & MS_REC) {
+	if ((mpt.flags & MS_REC) && (mpt.flags & (MS_NOSUID | MS_NODEV | MS_NOEXEC))) {
 		FILE* f = fopen("/proc/self/mountinfo", "re");
-		if (f != nullptr) {
-			char* line = nullptr;
-			size_t len = 0;
-			const std::string prefix = (mpt.dst == "/") ? "/" : (mpt.dst + "/");
-			while (getline(&line, &len, f) != -1) {
-				/* mountinfo field 5 (0-indexed 4) is the mount point */
-				char* p = line;
-				for (int i = 0; i < 4 && p != nullptr; i++) {
-					p = strchr(p, ' ');
-					if (p != nullptr) {
-						p++;
-					}
-				}
-				if (p == nullptr) {
-					continue;
-				}
-				char* endp = strchr(p, ' ');
-				if (endp == nullptr) {
-					continue;
-				}
-				std::string mp(p, endp - p);
-				if (mp != mpt.dst && mp.compare(0, prefix.size(), prefix) == 0) {
-					/* best-effort; remountOne logs any submount it can't
-					 * re-flag */
-					remountOne(mp, mpt);
+		if (f == nullptr) {
+			PLOG_W("fopen('/proc/self/mountinfo')");
+			return false;
+		}
+
+		bool success = true;
+		char* line = nullptr;
+		size_t len = 0;
+		const std::string prefix = (mpt.dst == "/") ? "/" : (mpt.dst + "/");
+		while (getline(&line, &len, f) != -1) {
+			/* mountinfo field 5 (0-indexed 4) is the mount point */
+			char* p = line;
+			for (int i = 0; i < 4 && p != nullptr; i++) {
+				p = strchr(p, ' ');
+				if (p != nullptr) {
+					p++;
 				}
 			}
-			free(line);
-			fclose(f);
+			if (p == nullptr) {
+				continue;
+			}
+			char* endp = strchr(p, ' ');
+			if (endp == nullptr) {
+				continue;
+			}
+			std::string mp(p, endp - p);
+			if (mp != mpt.dst && mp.compare(0, prefix.size(), prefix) == 0 &&
+			    !remountOne(mp, mpt)) {
+				success = false;
+				break;
+			}
+		}
+		free(line);
+		fclose(f);
+		if (!success) {
+			return false;
 		}
 	}
 	return true;

--- a/mnt_newapi.cc
+++ b/mnt_newapi.cc
@@ -496,6 +496,10 @@ static bool doBindMountAt(mount_t* mpt, int parent_fd, const char* basename) {
 	 */
 	if (!applyMountFlags(mnt_fd, mpt->flags & ~MS_RDONLY, true, (mpt->flags & MS_REC) != 0)) {
 		LOG_W("Failed to apply mount flags to '%s'", basename);
+		if ((mpt->flags & MS_REC) && (mpt->flags & (MS_NOSUID | MS_NODEV | MS_NOEXEC))) {
+			close(mnt_fd);
+			return false;
+		}
 	}
 
 	if (util::syscall(__NR_move_mount, (uintptr_t)mnt_fd, (uintptr_t)"", (uintptr_t)parent_fd,


### PR DESCRIPTION
## Summary

Fail closed when explicit `nosuid`, `nodev`, or `noexec` restrictions cannot be applied recursively to a recursive bind mount.

## Problem

Recursive bind mounts clone nested submounts. nsjail propagates requested mount restrictions to those nested mounts, but failures in that recursive enforcement path can currently be logged and ignored.

With the new mount API, `doBindMountAt()` can continue to `move_mount()` after recursive `applyMountFlags()` fails. With the legacy backend, failure to open `/proc/self/mountinfo` or to re-flag a nested submount is treated as best-effort success.

For a mount that explicitly requests `nosuid`, `nodev`, or `noexec`, that can leave the sandbox with weaker nested-mount semantics than requested while mount setup still reports success.

## Fix

- New mount API: abort before `move_mount()` if recursive enforcement of explicit `nosuid`, `nodev`, or `noexec` restrictions fails.
- Legacy backend: return failure if `/proc/self/mountinfo` cannot be opened or if re-flagging a nested submount fails while those restrictions are requested.
- Preserve the existing behavior for recursive binds that do not request these explicit security restrictions.

## Validation

- `git diff --check` passes.
- `make -j2` passes.
- Command-line parsing tests pass.
- `tests/nstun_buffer_budget_test`, `tests/nstun_policy_test`, and `tests/nstun_ip_test` pass.
- The full `make test` run on this development host stops at the first namespace sanity test because the host denies writing `/proc/<pid>/setgroups`; that happens before the changed mount-enforcement path is reached.
