### PR TITLE
nstun: enforce flow limits across address families

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ endif
 
 BIN = nsjail
 LIBS = kafel/libkafel.a
-TEST_BINS = tests/nstun_buffer_budget_test tests/nstun_policy_test tests/nstun_ip_test
+TEST_BINS = tests/nstun_buffer_budget_test tests/nstun_flow_limit_test tests/nstun_policy_test tests/nstun_ip_test
 
 # If PASTA_BIN_PATH is not provided in env, dynamically search for it if EMBED_PASTA is requested
 # or fallback to it naturally.
@@ -162,6 +162,7 @@ test-cmdline: $(BIN)
 .PHONY: test
 test: $(BIN) $(TEST_BINS) test-cmdline
 	$(call run_test, ./tests/nstun_buffer_budget_test, 0)
+	$(call run_test, ./tests/nstun_flow_limit_test, 0)
 	$(call run_test, ./tests/nstun_policy_test, 0)
 	$(call run_test, ./tests/nstun_ip_test, 0)
 	# --- Basic sanity tests ---
@@ -263,6 +264,9 @@ endif
 	@echo ""
 
 tests/nstun_buffer_budget_test: tests/nstun_buffer_budget_test.cc nstun/buffer_budget.h
+	$(CXX) $(filter-out -c,$(CXXFLAGS)) $< -o $@
+
+tests/nstun_flow_limit_test: tests/nstun_flow_limit_test.cc nstun/flow_limit.h
 	$(CXX) $(filter-out -c,$(CXXFLAGS)) $< -o $@
 
 tests/nstun_policy_test: tests/nstun_policy_test.cc nstun/policy.cc logs.cc util.cc $(SRCS_PB_CXX)

--- a/nstun/flow_limit.h
+++ b/nstun/flow_limit.h
@@ -1,0 +1,17 @@
+#ifndef NSTUN_FLOW_LIMIT_H_
+#define NSTUN_FLOW_LIMIT_H_
+
+#include <stddef.h>
+
+namespace nstun {
+
+[[nodiscard]] inline bool flow_limit_reached(size_t ipv4_count, size_t ipv6_count, size_t limit) {
+	if (ipv4_count >= limit) {
+		return true;
+	}
+	return ipv6_count >= limit - ipv4_count;
+}
+
+} /* namespace nstun */
+
+#endif /* NSTUN_FLOW_LIMIT_H_ */

--- a/nstun/icmp.cc
+++ b/nstun/icmp.cc
@@ -10,6 +10,7 @@
 #include <unistd.h>
 
 #include "core.h"
+#include "flow_limit.h"
 #include "logs.h"
 #include "macros.h"
 #include "policy.h"
@@ -211,9 +212,10 @@ void handle_icmp6(Context* ctx, const ip6_hdr* ip, std::span<const uint8_t> payl
 				flow = it->second.get();
 				flow->last_active = time(NULL);
 			} else {
-				if (ctx->ipv6_icmp_flows_by_key.size() >= NSTUN_MAX_FLOWS) {
-					LOG_W("Maximum number of IPv6 ICMP flows (%zu) reached, "
-					      "dropping",
+				if (flow_limit_reached(ctx->ipv4_icmp_flows_by_key.size(),
+					ctx->ipv6_icmp_flows_by_key.size(), NSTUN_MAX_FLOWS)) {
+					LOG_W(
+					    "Maximum number of ICMP flows (%zu) reached, dropping",
 					    NSTUN_MAX_FLOWS);
 					return;
 				}
@@ -329,7 +331,8 @@ void handle_icmp4(Context* ctx, const ip4_hdr* ip, std::span<const uint8_t> payl
 				flow = it->second.get();
 				flow->last_active = time(NULL);
 			} else {
-				if (ctx->ipv4_icmp_flows_by_key.size() >= NSTUN_MAX_FLOWS) {
+				if (flow_limit_reached(ctx->ipv4_icmp_flows_by_key.size(),
+					ctx->ipv6_icmp_flows_by_key.size(), NSTUN_MAX_FLOWS)) {
 					LOG_W(
 					    "Maximum number of ICMP flows (%zu) reached, dropping",
 					    NSTUN_MAX_FLOWS);

--- a/nstun/tcp.cc
+++ b/nstun/tcp.cc
@@ -12,6 +12,7 @@
 #include <unistd.h>
 
 #include "encap.h"
+#include "flow_limit.h"
 #include "logs.h"
 #include "macros.h"
 #include "policy.h"
@@ -850,7 +851,8 @@ void handle_tcp4(Context* ctx, const ip4_hdr* ip, std::span<const uint8_t> paylo
 		flow = it->second.get();
 		flow->last_active = time(NULL);
 	} else {
-		if (ctx->ipv4_tcp_flows_by_key.size() >= NSTUN_MAX_FLOWS) {
+		if (flow_limit_reached(ctx->ipv4_tcp_flows_by_key.size(),
+			ctx->ipv6_tcp_flows_by_key.size(), NSTUN_MAX_FLOWS)) {
 			LOG_W(
 			    "Maximum number of TCP flows (%zu) reached, dropping", NSTUN_MAX_FLOWS);
 			return;
@@ -1292,9 +1294,10 @@ void handle_tcp6(Context* ctx, const ip6_hdr* ip, std::span<const uint8_t> paylo
 		flow = it->second.get();
 		flow->last_active = time(NULL);
 	} else {
-		if (ctx->ipv6_tcp_flows_by_key.size() >= NSTUN_MAX_FLOWS) {
-			LOG_W("Maximum number of IPv6 TCP flows (%zu) reached, dropping",
-			    NSTUN_MAX_FLOWS);
+		if (flow_limit_reached(ctx->ipv4_tcp_flows_by_key.size(),
+			ctx->ipv6_tcp_flows_by_key.size(), NSTUN_MAX_FLOWS)) {
+			LOG_W(
+			    "Maximum number of TCP flows (%zu) reached, dropping", NSTUN_MAX_FLOWS);
 			return;
 		}
 

--- a/nstun/udp.cc
+++ b/nstun/udp.cc
@@ -12,6 +12,7 @@
 
 #include "core.h"
 #include "encap.h"
+#include "flow_limit.h"
 #include "icmp.h"
 #include "logs.h"
 #include "macros.h"
@@ -431,7 +432,8 @@ void handle_udp4(Context* ctx, const ip4_hdr* ip, std::span<const uint8_t> paylo
 		flow = it->second.get();
 		flow->last_active = time(NULL);
 	} else {
-		if (ctx->ipv4_udp_flows_by_key.size() >= NSTUN_MAX_FLOWS) {
+		if (flow_limit_reached(ctx->ipv4_udp_flows_by_key.size(),
+			ctx->ipv6_udp_flows_by_key.size(), NSTUN_MAX_FLOWS)) {
 			LOG_W(
 			    "Maximum number of UDP flows (%zu) reached, dropping", NSTUN_MAX_FLOWS);
 			return;
@@ -732,8 +734,9 @@ void handle_host_udp_accept(Context* ctx, int listen_fd, const nstun_rule_t& rul
 				flow = it->second.get();
 				flow->last_active = time(NULL);
 			} else {
-				if (ctx->ipv6_udp_flows_by_key.size() >= NSTUN_MAX_FLOWS) {
-					LOG_W("Maximum number of IPv6 UDP flows reached, dropping");
+				if (flow_limit_reached(ctx->ipv4_udp_flows_by_key.size(),
+					ctx->ipv6_udp_flows_by_key.size(), NSTUN_MAX_FLOWS)) {
+					LOG_W("Maximum number of UDP flows reached, dropping");
 					continue;
 				}
 				auto flow_ptr = std::make_unique<UdpFlow>();
@@ -798,7 +801,8 @@ void handle_host_udp_accept(Context* ctx, int listen_fd, const nstun_rule_t& rul
 				flow = it->second.get();
 				flow->last_active = time(NULL);
 			} else {
-				if (ctx->ipv4_udp_flows_by_key.size() >= NSTUN_MAX_FLOWS) {
+				if (flow_limit_reached(ctx->ipv4_udp_flows_by_key.size(),
+					ctx->ipv6_udp_flows_by_key.size(), NSTUN_MAX_FLOWS)) {
 					LOG_W("Maximum number of UDP flows reached, dropping");
 					continue;
 				}
@@ -919,9 +923,10 @@ void handle_udp6(Context* ctx, const ip6_hdr* ip, std::span<const uint8_t> paylo
 		flow = it->second.get();
 		flow->last_active = time(NULL);
 	} else {
-		if (ctx->ipv6_udp_flows_by_key.size() >= NSTUN_MAX_FLOWS) {
-			LOG_W("Maximum number of IPv6 UDP flows (%zu) reached, dropping",
-			    NSTUN_MAX_FLOWS);
+		if (flow_limit_reached(ctx->ipv4_udp_flows_by_key.size(),
+			ctx->ipv6_udp_flows_by_key.size(), NSTUN_MAX_FLOWS)) {
+			LOG_W(
+			    "Maximum number of UDP flows (%zu) reached, dropping", NSTUN_MAX_FLOWS);
 			return;
 		}
 

--- a/tests/nstun_flow_limit_test.cc
+++ b/tests/nstun_flow_limit_test.cc
@@ -1,0 +1,19 @@
+#include <limits>
+
+#include "nstun/flow_limit.h"
+
+int main() {
+	constexpr size_t limit = 1024;
+	if (nstun::flow_limit_reached(0, 0, limit)) return 1;
+	if (nstun::flow_limit_reached(1023, 0, limit)) return 2;
+	if (nstun::flow_limit_reached(0, 1023, limit)) return 3;
+	if (nstun::flow_limit_reached(512, 511, limit)) return 4;
+	if (!nstun::flow_limit_reached(512, 512, limit)) return 5;
+	if (!nstun::flow_limit_reached(1024, 0, limit)) return 6;
+	if (!nstun::flow_limit_reached(0, 1024, limit)) return 7;
+	if (!nstun::flow_limit_reached(
+		std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max(), limit)) {
+		return 8;
+	}
+	return 0;
+}


### PR DESCRIPTION
## Summary

nstun keeps separate IPv4 and IPv6 flow maps, but the outbound TCP, UDP, and ICMP admission checks applied `NSTUN_MAX_FLOWS` to each address-family map independently. A dual-stack workload could therefore exceed the intended per-protocol flow bound by filling both maps.

This change adds a small overflow-safe aggregate flow-limit helper and uses it when admitting outbound TCP, UDP, and ICMP flows so the limit is enforced across both address families together. It also adds a focused regression test for boundary and overflow cases.

## Testing

- `make -j2` — passed
- `tests/nstun_flow_limit_test` — passed
- `make test` — command-line, nstun buffer-budget, policy, IP, and flow-limit tests passed; the suite later stopped at a namespace sanity test because this host denies writing `/proc/<pid>/setgroups` (`Permission denied`)
- `git diff --check` — passed
