### PR TITLE
nstun: preserve partial redirect targets

### DIFF
--- a/nstun/policy.cc
+++ b/nstun/policy.cc
@@ -140,7 +140,7 @@ RuleResult evaluate_rules6(Context* ctx, nstun_direction_t dir, nstun_proto_t pr
 
 		RuleResult res = {r.action, 0, 0, false, {}};
 		if (r.action == NSTUN_ACTION_REDIRECT) {
-			res.has_redirect_ip6 = true;
+			res.has_redirect_ip6 = !ip6_is_zero(r.redirect_ip6);
 			memcpy(res.redirect_ip6, r.redirect_ip6, sizeof(res.redirect_ip6));
 			res.redirect_port = r.redirect_port;
 		} else if (r.action == NSTUN_ACTION_ENCAP_SOCKS5 ||

--- a/nstun/tcp.cc
+++ b/nstun/tcp.cc
@@ -891,7 +891,15 @@ void handle_tcp4(Context* ctx, const ip4_hdr* ip, std::span<const uint8_t> paylo
 		}
 
 		struct sockaddr_in dest_addr = INIT_SOCKADDR_IN(AF_INET);
-		if (rule.redirect_ip4 && rule.redirect_port) {
+		if (rule.action == NSTUN_ACTION_REDIRECT) {
+			dest_addr.sin_addr.s_addr =
+			    rule.redirect_ip4 ? rule.redirect_ip4 : key4.daddr4;
+			dest_addr.sin_port =
+			    rule.redirect_port ? htons(rule.redirect_port) : tcp->dest;
+			LOG_D("Redirecting TCP flow guest %u to host %s:%u via policy (fd=%d)",
+			    guest_port, ip4_to_string(dest_addr.sin_addr.s_addr).c_str(),
+			    ntohs(dest_addr.sin_port), fd);
+		} else if (rule.redirect_ip4 && rule.redirect_port) {
 			dest_addr.sin_addr.s_addr = rule.redirect_ip4;
 			dest_addr.sin_port = htons(rule.redirect_port);
 			LOG_D("Redirecting TCP flow guest %u to host %s:%u via policy (fd=%d)",
@@ -1360,14 +1368,16 @@ void handle_tcp6(Context* ctx, const ip6_hdr* ip, std::span<const uint8_t> paylo
 		} else {
 			/* Direct IPv6 connection (or IPv6 redirect) */
 			struct sockaddr_in6 dest_addr = INIT_SOCKADDR_IN6(AF_INET6);
-			if (rule.has_redirect_ip6 && rule.redirect_port) {
-				memcpy(&dest_addr.sin6_addr, rule.redirect_ip6,
+			if (rule.action == NSTUN_ACTION_REDIRECT) {
+				memcpy(&dest_addr.sin6_addr,
+				    rule.has_redirect_ip6 ? rule.redirect_ip6 : key6.daddr6,
 				    sizeof(dest_addr.sin6_addr));
-				dest_addr.sin6_port = htons(rule.redirect_port);
+				dest_addr.sin6_port =
+				    rule.redirect_port ? htons(rule.redirect_port) : tcp->dest;
 				LOG_D("Redirecting IPv6 TCP flow guest %u to %s:%u via policy "
 				      "(fd=%d)",
-				    guest_port, ip6_to_string(rule.redirect_ip6).c_str(),
-				    rule.redirect_port, fd);
+				    guest_port, ip6_to_string(dest_addr.sin6_addr.s6_addr).c_str(),
+				    ntohs(dest_addr.sin6_port), fd);
 			} else {
 				memcpy(
 				    &dest_addr.sin6_addr, key6.daddr6, sizeof(dest_addr.sin6_addr));

--- a/nstun/udp.cc
+++ b/nstun/udp.cc
@@ -557,9 +557,11 @@ void handle_udp4(Context* ctx, const ip4_hdr* ip, std::span<const uint8_t> paylo
 		/* Use the redirect destination stored in the flow at creation time.
 		 * Do NOT re-evaluate the rule - it may yield different results
 		 * for packets on an already-established flow. */
-		if (flow->redirect_ip4 && flow->redirect_port) {
-			dest_addr.sin_addr.s_addr = flow->redirect_ip4;
-			dest_addr.sin_port = htons(flow->redirect_port);
+		if (flow->is_redirected) {
+			dest_addr.sin_addr.s_addr =
+			    flow->redirect_ip4 ? flow->redirect_ip4 : ip->daddr;
+			dest_addr.sin_port =
+			    flow->redirect_port ? htons(flow->redirect_port) : htons(dest_port);
 		} else {
 			dest_addr.sin_addr.s_addr = ip->daddr;
 			dest_addr.sin_port = htons(dest_port);
@@ -1047,10 +1049,11 @@ void handle_udp6(Context* ctx, const ip6_hdr* ip, std::span<const uint8_t> paylo
 		 * Do NOT re-evaluate the rule for packets on an existing flow. */
 		bool has_redirect = !std::equal(std::begin(flow->redirect_ip6),
 		    std::end(flow->redirect_ip6), std::begin(std::array<uint8_t, IPV6_ADDR_LEN>{}));
-		if (has_redirect && flow->redirect_port) {
-			memcpy(
-			    &dest_addr.sin6_addr, flow->redirect_ip6, sizeof(dest_addr.sin6_addr));
-			dest_addr.sin6_port = htons(flow->redirect_port);
+		if (flow->is_redirected) {
+			memcpy(&dest_addr.sin6_addr, has_redirect ? flow->redirect_ip6 : ip->daddr,
+			    sizeof(dest_addr.sin6_addr));
+			dest_addr.sin6_port =
+			    flow->redirect_port ? htons(flow->redirect_port) : htons(dest_port);
 		} else {
 			memcpy(&dest_addr.sin6_addr, ip->daddr, sizeof(dest_addr.sin6_addr));
 			dest_addr.sin6_port = htons(dest_port);

--- a/tests/nstun_policy_test.cc
+++ b/tests/nstun_policy_test.cc
@@ -8,6 +8,7 @@
 
 #include "config.pb.h"
 #include "nstun/policy.h"
+#include "nstun/tcp.h"
 
 static uint32_t parse_ip4(const char* str) {
 	uint32_t addr;
@@ -62,6 +63,33 @@ static nstun::RuleParseStatus parse_common(
 	return nstun::fill_rule_common(rule, parsed);
 }
 
+static void test_ipv6_redirect_presence() {
+	auto* ctx = new nstun::Context();
+	nstun_rule_t rule = {};
+	rule.direction = NSTUN_DIR_GUEST_TO_HOST;
+	rule.action = NSTUN_ACTION_REDIRECT;
+	rule.proto = NSTUN_PROTO_TCP;
+	rule.is_ipv6 = true;
+	rule.redirect_port = 8443;
+	ctx->rules.push_back(rule);
+
+	std::array<uint8_t, 16> src = {};
+	std::array<uint8_t, 16> dst = {};
+	auto result = nstun::evaluate_rules6(
+	    ctx, NSTUN_DIR_GUEST_TO_HOST, NSTUN_PROTO_TCP, src.data(), dst.data(), 12345, 443);
+	assert(result.action == NSTUN_ACTION_REDIRECT);
+	assert(!result.has_redirect_ip6);
+	assert(result.redirect_port == 8443);
+
+	std::array<uint8_t, 16> redirect = {};
+	assert(inet_pton(AF_INET6, "2001:db8::1", redirect.data()) == 1);
+	std::copy(redirect.begin(), redirect.end(), ctx->rules[0].redirect_ip6);
+	result = nstun::evaluate_rules6(
+	    ctx, NSTUN_DIR_GUEST_TO_HOST, NSTUN_PROTO_TCP, src.data(), dst.data(), 12345, 443);
+	assert(result.has_redirect_ip6);
+	assert(std::equal(redirect.begin(), redirect.end(), result.redirect_ip6));
+}
+
 static void test_port_validation() {
 	nsjail::NsJailConfig_UserNet_NstunRule rule;
 	nstun_rule_t parsed = {};
@@ -97,6 +125,7 @@ static void test_port_validation() {
 int main() {
 	test_ip4_cidr();
 	test_ip6_cidr();
+	test_ipv6_redirect_presence();
 	test_port_validation();
 	return 0;
 }


### PR DESCRIPTION
## Summary

`NstunRule` allows `redirect_ip` and `redirect_port` to be specified independently, but the TCP and UDP forwarding paths only applied a redirect when both values were non-zero. A rule that redirected only the address or only the port could therefore fall through to the original destination instead of preserving the unspecified component.

Use the matched `REDIRECT` action / stored redirect state as the source of truth. When one redirect component is omitted, preserve that component from the original destination. Also avoid marking an all-zero IPv6 redirect address as present.

## Validation

- `make -j2 tests/nstun_policy_test nsjail`: passed
- `./tests/nstun_policy_test`: passed
- `git diff --check origin/master...HEAD`: passed
- `make test`: command-line parsing tests, `nstun_buffer_budget_test`, `nstun_policy_test`, and `nstun_ip_test` passed; the suite then stopped at the first namespace sanity test because this host denies writing `/proc/<pid>/setgroups` (`Permission denied`)
