### PR TITLE
nstun: validate ICMP reply peers

### DIFF
--- a/nstun/core.h
+++ b/nstun/core.h
@@ -138,6 +138,10 @@ struct IcmpFlow : public Flow {
 		uint32_t orig_dest_ip4;
 		uint8_t orig_dest_ip6[IPV6_ADDR_LEN];
 	};
+	union {
+		uint32_t host_peer_ip4;
+		uint8_t host_peer_ip6[IPV6_ADDR_LEN];
+	};
 
 	~IcmpFlow() override {
 		if (host_fd != -1) ::close(host_fd);

--- a/nstun/icmp.cc
+++ b/nstun/icmp.cc
@@ -249,6 +249,9 @@ void handle_icmp6(Context* ctx, const ip6_hdr* ip, std::span<const uint8_t> payl
 				flow->last_active = time(NULL);
 				flow->is_redirected = rule.has_redirect_ip6;
 				memcpy(flow->orig_dest_ip6, ip->daddr, sizeof(flow->orig_dest_ip6));
+				memcpy(flow->host_peer_ip6,
+				    rule.has_redirect_ip6 ? rule.redirect_ip6 : ip->daddr,
+				    sizeof(flow->host_peer_ip6));
 
 				ctx->ipv6_icmp_flows_by_key[key6] = std::move(flow_ptr);
 				ctx->flows_by_fd[fd] = flow;
@@ -373,6 +376,8 @@ void handle_icmp4(Context* ctx, const ip4_hdr* ip, std::span<const uint8_t> payl
 				flow->last_active = time(NULL);
 				flow->is_redirected = (rule.redirect_ip4 != 0);
 				flow->orig_dest_ip4 = ip->daddr;
+				flow->host_peer_ip4 =
+				    (rule.redirect_ip4 != 0) ? rule.redirect_ip4 : ip->daddr;
 
 				ctx->ipv4_icmp_flows_by_key[key4] = std::move(flow_ptr);
 				ctx->flows_by_fd[fd] = flow;
@@ -440,6 +445,14 @@ static void handle_host_icmp(Context* ctx, IcmpFlow* flow) {
 		uint8_t* data_ptr = bufs[i];
 		size_t recv_len = msgs[i].msg_len;
 		struct sockaddr_storage* src_addr_storage = &src_addrs[i];
+
+		bool peer_matches = flow->is_ipv6
+					? sockaddr_matches_ip6(*src_addr_storage, flow->host_peer_ip6)
+					: sockaddr_matches_ip4(*src_addr_storage, flow->host_peer_ip4);
+		if (!peer_matches) {
+			LOG_W("Dropping ICMP datagram from unexpected peer");
+			continue;
+		}
 
 		if (flow->is_ipv6) {
 			if ((size_t)recv_len >= sizeof(icmp6_hdr)) {

--- a/nstun/net_defs.h
+++ b/nstun/net_defs.h
@@ -31,6 +31,19 @@ inline bool ip6_is_aws_local_service(const uint8_t addr[16]) {
 	return memcmp(addr, prefix, sizeof(prefix)) == 0;
 }
 
+inline bool sockaddr_matches_ip4(const struct sockaddr_storage& peer, uint32_t expected_addr) {
+	if (peer.ss_family != AF_INET) return false;
+	const auto* peer4 = reinterpret_cast<const struct sockaddr_in*>(&peer);
+	return peer4->sin_addr.s_addr == expected_addr;
+}
+
+inline bool sockaddr_matches_ip6(
+    const struct sockaddr_storage& peer, const uint8_t expected_addr[IPV6_ADDR_LEN]) {
+	if (peer.ss_family != AF_INET6) return false;
+	const auto* peer6 = reinterpret_cast<const struct sockaddr_in6*>(&peer);
+	return memcmp(&peer6->sin6_addr, expected_addr, IPV6_ADDR_LEN) == 0;
+}
+
 struct __attribute__((packed)) ip4_hdr {
 	uint8_t ihl_version; /* version << 4 | ihl */
 	uint8_t tos;

--- a/tests/nstun_ip_test.cc
+++ b/tests/nstun_ip_test.cc
@@ -19,6 +19,22 @@ static bool ip6_is_aws_local_service(const char* str) {
 	return nstun::ip6_is_aws_local_service(addr.data());
 }
 
+static sockaddr_storage peer4(const char* ip) {
+	sockaddr_storage storage = {};
+	auto* addr = reinterpret_cast<sockaddr_in*>(&storage);
+	addr->sin_family = AF_INET;
+	addr->sin_addr.s_addr = parse_ip4(ip);
+	return storage;
+}
+
+static sockaddr_storage peer6(const char* ip) {
+	sockaddr_storage storage = {};
+	auto* addr = reinterpret_cast<sockaddr_in6*>(&storage);
+	addr->sin6_family = AF_INET6;
+	assert(inet_pton(AF_INET6, ip, &addr->sin6_addr) == 1);
+	return storage;
+}
+
 int main() {
 	assert(!nstun::ip4_is_link_local(parse_ip4("169.253.255.255")));
 	assert(nstun::ip4_is_link_local(parse_ip4("169.254.0.0")));
@@ -35,5 +51,16 @@ int main() {
 	assert(!ip6_is_aws_local_service("fd00:ec3::"));
 	assert(!ip6_is_aws_local_service("fc00::1"));
 	assert(!ip6_is_aws_local_service("fe80::1"));
+
+	uint32_t expected4 = parse_ip4("203.0.113.10");
+	assert(nstun::sockaddr_matches_ip4(peer4("203.0.113.10"), expected4));
+	assert(!nstun::sockaddr_matches_ip4(peer4("203.0.113.11"), expected4));
+	assert(!nstun::sockaddr_matches_ip4(peer6("2001:db8::10"), expected4));
+
+	std::array<uint8_t, 16> expected6 = {};
+	assert(inet_pton(AF_INET6, "2001:db8::10", expected6.data()) == 1);
+	assert(nstun::sockaddr_matches_ip6(peer6("2001:db8::10"), expected6.data()));
+	assert(!nstun::sockaddr_matches_ip6(peer6("2001:db8::11"), expected6.data()));
+	assert(!nstun::sockaddr_matches_ip6(peer4("203.0.113.10"), expected6.data()));
 	return 0;
 }


### PR DESCRIPTION
## Summary

Validate the sender address of host-side ICMP replies before forwarding them into an nstun guest flow.

ICMP proxy flows use unconnected datagram sockets. Previously, `handle_host_icmp()` accepted any datagram delivered to a flow socket. For a direct flow, that could associate a reply from a peer other than the flow destination with the guest flow. For a redirected flow, the reply path additionally rewrites the source address to the guest's original destination, so an unexpected sender could be misattributed as that destination.

This change stores the actual host-side peer selected when each ICMP flow is created (the original destination or the redirect target) and drops replies whose address family/address does not match it before constructing a packet for the guest.

## Validation

- `make -j2 tests/nstun_ip_test nsjail`: PASS
- `tests/nstun_ip_test`: PASS, including IPv4/IPv6 expected-address, wrong-address, and wrong-family cases
- `nstun_buffer_budget_test` and `nstun_policy_test`: PASS
- command-line tests in `make test`: PASS
- `git diff --check`: PASS

The full `make test` run reaches and passes the command-line and nstun unit tests, then stops at the first namespace sanity test because this host denies writing `/proc/<pid>/setgroups`. That environment restriction occurs after the changed nstun tests have completed.
