### PR TITLE
cmdline: reject inconsistent cgroup memory limits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,7 @@ test-cmdline: $(BIN)
 	$(call run_test, ./nsjail --user 1000:1000:1.5 --help > /dev/null, 255)
 	$(call run_test, ./nsjail --rlimit_cpu 1.5 --help > /dev/null, 255)
 	$(call run_test, ./nsjail --time_limit 0x10 --cgroup_mem_swap_max=-1 --user 1000:1000:1 --help > /dev/null, 0)
+	$(call run_test, ./nsjail -Mo --cgroup_mem_max=200 --cgroup_mem_memsw_max=100 -- /bin/true, 255)
 
 .PHONY: test
 test: $(BIN) $(TEST_BINS) test-cmdline

--- a/cmdline.cc
+++ b/cmdline.cc
@@ -1133,6 +1133,10 @@ std::unique_ptr<nsj_t> parseArgs(int argc, char* argv[]) {
 	    nsj->njc.cgroup_mem_swap_max() >= (ssize_t)0) {
 		LOG_F("cannot set both cgroup_mem_memsw_max and cgroup_mem_swap_max");
 	}
+	if (nsj->njc.cgroup_mem_memsw_max() > (size_t)0 &&
+	    nsj->njc.cgroup_mem_memsw_max() < nsj->njc.cgroup_mem_max()) {
+		LOG_F("cgroup_mem_memsw_max cannot be smaller than cgroup_mem_max");
+	}
 
 	return nsj;
 }


### PR DESCRIPTION
## Summary

Reject configurations where `cgroup_mem_memsw_max` is smaller than `cgroup_mem_max`.

`cgroup_mem_memsw_max` represents a combined memory+swap limit. On cgroup v2 nsjail derives `memory.swap.max` by subtracting `cgroup_mem_max` from that value. When the combined limit is smaller than the memory limit, that unsigned subtraction underflows before being stored in the signed swap-limit variable. The resulting negative value can cause the `memory.swap.max` write to be skipped, silently weakening the requested resource boundary.

Reject the inconsistent relationship during argument/config validation instead of allowing the cgroup setup path to interpret the underflowed value.

## Validation

- `make -j2 nsjail`: PASS
- `make test-cmdline`: PASS, including the new inconsistent-limit regression
- `git diff --check`: PASS
- full `make test`: command-line tests and all nstun unit tests pass; the suite then stops at the existing host restriction that denies writing `/proc/<pid>/setgroups`
- an unmodified build accepts the inconsistent relation and proceeds into cgroup setup; the patched build rejects it during parsing

Git history and upstream PR/issue searches found no equivalent validation change. Historical PRs #184 and #186 added the memsw controls, and #278 adjusted swap-only cleanup, but none reject this invalid limit relationship.
