### PR TITLE
mnt: re-flag every submount of a recursive bind

### DIFF
--- a/mnt_legacy.cc
+++ b/mnt_legacy.cc
@@ -297,6 +297,34 @@ static bool remountOne(const std::string& path, const mnt::mount_t& mpt) {
 	return true;
 }
 
+/*
+ * Mount points in /proc/self/mountinfo are escaped: space, tab, newline and
+ * backslash are written as octal escapes. Decode the field before comparing it
+ * with the mount destination.
+ */
+static bool decodeMountInfoPath(const char* begin, const char* end, std::string* decoded) {
+	decoded->clear();
+	decoded->reserve(end - begin);
+
+	for (const char* p = begin; p < end; p++) {
+		if (*p != '\\') {
+			decoded->push_back(*p);
+			continue;
+		}
+		if (end - p < 4 || p[1] < '0' || p[1] > '3' || p[2] < '0' || p[2] > '7' ||
+		    p[3] < '0' || p[3] > '7') {
+			return false;
+		}
+		const unsigned int value = ((p[1] - '0') << 6) | ((p[2] - '0') << 3) | (p[3] - '0');
+		if (value == 0) {
+			return false;
+		}
+		decoded->push_back(static_cast<char>(value));
+		p += 3;
+	}
+	return true;
+}
+
 bool remountPt(mnt::mount_t& mpt) {
 	if (!mpt.mounted || mpt.mpt->is_symlink()) {
 		return true;
@@ -338,7 +366,11 @@ bool remountPt(mnt::mount_t& mpt) {
 				if (endp == nullptr) {
 					continue;
 				}
-				std::string mp(p, endp - p);
+				std::string mp;
+				if (!decodeMountInfoPath(p, endp, &mp)) {
+					LOG_W("Malformed mount point in /proc/self/mountinfo");
+					continue;
+				}
 				if (mp != mpt.dst && mp.compare(0, prefix.size(), prefix) == 0) {
 					/* best-effort; remountOne logs any submount it can't
 					 * re-flag */

--- a/mnt_legacy.cc
+++ b/mnt_legacy.cc
@@ -24,6 +24,10 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/mount.h>
+// clang-format off
+/* <linux/mount.h> must follow <sys/mount.h>, see google/nsjail#250 */
+#include <linux/mount.h>
+// clang-format on
 #include <sys/stat.h>
 #include <sys/statvfs.h>
 #include <sys/syscall.h>
@@ -38,6 +42,7 @@
 
 #include "logs.h"
 #include "macros.h"
+#include "missing_defs.h"
 #include "mnt.h"
 #include "util.h"
 
@@ -325,6 +330,40 @@ static bool decodeMountInfoPath(const char* begin, const char* end, std::string*
 	return true;
 }
 
+/*
+ * Apply the requested restrictions to a whole mount subtree in one call.
+ * Unlike a bind remount, mount_setattr(AT_RECURSIVE) also covers submounts
+ * that reject MS_REMOUNT (autofs, for one) and mounts the kernel locked
+ * together when the user namespace was created. Restrictions are only set,
+ * never cleared, which is what the kernel permits on locked mounts.
+ */
+static bool setSubtreeAttrs(const std::string& path, uintptr_t flags) {
+	struct mount_attr attr = {};
+
+	if (flags & MS_RDONLY) {
+		attr.attr_set |= MOUNT_ATTR_RDONLY;
+	}
+	if (flags & MS_NOSUID) {
+		attr.attr_set |= MOUNT_ATTR_NOSUID;
+	}
+	if (flags & MS_NODEV) {
+		attr.attr_set |= MOUNT_ATTR_NODEV;
+	}
+	if (flags & MS_NOEXEC) {
+		attr.attr_set |= MOUNT_ATTR_NOEXEC;
+	}
+	if (attr.attr_set == 0) {
+		return true;
+	}
+
+	if (util::syscall(__NR_mount_setattr, (uintptr_t)AT_FDCWD, (uintptr_t)path.c_str(),
+		(uintptr_t)AT_RECURSIVE, (uintptr_t)&attr, sizeof(attr)) < 0) {
+		PLOG_D("mount_setattr('%s', AT_RECURSIVE)", path.c_str());
+		return false;
+	}
+	return true;
+}
+
 bool remountPt(mnt::mount_t& mpt) {
 	if (!mpt.mounted || mpt.mpt->is_symlink()) {
 		return true;
@@ -345,6 +384,12 @@ bool remountPt(mnt::mount_t& mpt) {
 	 * attributes with mount_setattr(AT_RECURSIVE).
 	 */
 	if (mpt.flags & MS_REC) {
+		if (setSubtreeAttrs(mpt.dst, mpt.flags)) {
+			return true;
+		}
+		LOG_D("mount_setattr() failed for '%s', re-flagging each submount instead",
+		    mpt.dst.c_str());
+
 		FILE* f = fopen("/proc/self/mountinfo", "re");
 		if (f != nullptr) {
 			char* line = nullptr;


### PR DESCRIPTION
Two problems in the recursive re-flagging pass of the legacy mount backend.

Mount points in `/proc/self/mountinfo` are escaped, so a submount whose path
contains a space, tab, newline or backslash never matched the destination
prefix and kept its original suid, dev and exec attributes. The first commit
decodes the field before comparing it.

The pass itself re-applies the flags with a bind remount, which fails for
filesystems that reject `MS_REMOUNT` (autofs, for one) and for mounts the
kernel locked together when the user namespace was created. Those submounts
stay in the jail with the wider attributes. The second commit applies the
restrictions with `mount_setattr(AT_RECURSIVE)` instead, which is what the new
mount API backend already does, and keeps the remount loop as a fallback for
kernels without the syscall. Only restrictions are set, never cleared, which is
what the kernel permits on locked mounts.

Tested on Ubuntu 26.04, kernel 7.0.0-15-generic, gcc 15.2.0:

```
mount -t tmpfs none "/mnt/test/with space"
./nsjail -q -Mo --chroot / -- /bin/bash -c 'touch "/mnt/test/with space/x"'

before: succeeds, the submount stays writable under a read-only chroot
after:  fails
```

`--chroot /` also stops logging `mount('/proc/sys/fs/binfmt_misc', ...): Invalid
argument` on a systemd host, because the autofs submount no longer needs a bind
remount. Read-write binds are unaffected. Both paths were exercised: the first
commit alone fixes the spaced submount through the remount loop, the second
through `mount_setattr`.
