### PR TITLE
user: fail closed if supplementary groups survive a denied setgroups

### DIFF
--- a/user.cc
+++ b/user.cc
@@ -302,6 +302,18 @@ bool initNsFromChild(nsj_t* nsj) {
 			return false;
 		}
 
+		const int remainingGroups = getgroups(0, nullptr);
+		if (remainingGroups == -1) {
+			PLOG_E("getgroups(0, nullptr) failed");
+			return false;
+		}
+		if (remainingGroups != 0) {
+			errno = setgroupsErrno;
+			PLOG_E("setgroups(%zu, %s) failed and %d supplementary group(s) remain",
+			    groups.size(), groupsString.c_str(), remainingGroups);
+			return false;
+		}
+
 		errno = setgroupsErrno;
 		PLOG_D("setgroups(%zu, %s) failed (expected in unprivileged user namespace)",
 		    groups.size(), groupsString.c_str());


### PR DESCRIPTION
`make test` starts a jail from a process that carries an inherited
supplementary group and expects nsjail to refuse:

```
setpriv --reuid 1000 --regid 1000 --groups 1234 -- ./nsjail -q -Mo \
  --user 65534 --group 65534 --disable_clone_newnet --disable_clone_newcgroup \
  --disable_clone_newns --disable_clone_newpid --disable_clone_newipc \
  --disable_clone_newuts --disable_proc -- /bin/true
```

On Ubuntu 26.04 (kernel 7.0.0-15-generic) master returns 0 instead of the
expected 255. After the parent writes `deny` to `/proc/pid/setgroups`,
`setgroups(2)` fails with `EPERM` and that is treated as expected, but entering
a user namespace does not drop supplementary groups, so the jailed process
keeps the ones it inherited.

Check with `getgroups(2)` and fail if any group remains.

With the patch the test above returns 255 and logs `setgroups(0, []) failed and
1 supplementary group(s) remain`. The `--clear-groups` variant still returns 0,
and an ordinary jail still starts.
