### PR TITLE
nstun/tcp: drop guest packets received before the handshake completes

### DIFF
--- a/nstun/tcp.cc
+++ b/nstun/tcp.cc
@@ -582,8 +582,22 @@ static void tcp_process_data(Context* ctx, TcpFlow* flow, const tcp_hdr* tcp,
 	uint32_t seq = ntohl(tcp->seq);
 	uint32_t ack = ntohl(tcp->ack_seq);
 
-	if (flow->inbound && flow->state == TcpState::SYN_SENT &&
-	    (tcp->flags & NSTUN_TCP_FLAG_SYN) && (tcp->flags & NSTUN_TCP_FLAG_ACK)) {
+	if (tcp->flags & NSTUN_TCP_FLAG_RST) {
+		LOG_D("Received RST from guest");
+		tcp_destroy_flow(ctx, flow);
+		return;
+	}
+
+	if (flow->state == TcpState::SYN_SENT) {
+		if (!flow->inbound || !(tcp->flags & NSTUN_TCP_FLAG_SYN) ||
+		    !(tcp->flags & NSTUN_TCP_FLAG_ACK)) {
+			LOG_D("Ignoring packet before the TCP handshake is complete");
+			return;
+		}
+		if (ack != flow->seq_to_guest) {
+			LOG_D("Ignoring SYN-ACK with invalid ACK number");
+			return;
+		}
 		flow->state = TcpState::ESTABLISHED;
 		flow->ack_from_guest = ack;
 		flow->seq_from_guest = seq + 1;
@@ -607,15 +621,8 @@ static void tcp_process_data(Context* ctx, TcpFlow* flow, const tcp_hdr* tcp,
 		return;
 	}
 
-	if (tcp->flags & NSTUN_TCP_FLAG_RST) {
-		LOG_D("Received RST from guest");
-		tcp_destroy_flow(ctx, flow);
-		return;
-	}
-
 	if (flow->state == TcpState::ESTABLISHED || flow->state == TcpState::FIN_WAIT_1 ||
-	    flow->state == TcpState::FIN_WAIT_2 || flow->state == TcpState::SYN_SENT ||
-	    flow->state == TcpState::CLOSE_WAIT) {
+	    flow->state == TcpState::FIN_WAIT_2 || flow->state == TcpState::CLOSE_WAIT) {
 		const uint8_t* data = payload.data() + doff;
 		size_t data_len = payload.size() - doff;
 


### PR DESCRIPTION
A flow in `SYN_SENT` was also handled by the data path, so payload the guest
sent before the handshake completed was processed, and the SYN-ACK was accepted
without checking its acknowledgement number.

Handle RST first, require a valid SYN-ACK to leave `SYN_SENT`, and ignore
anything else until the flow is established.

Tested on Ubuntu 26.04, kernel 7.0.0-15-generic: the nstun unit tests,
`tests/nstun.cfg` (outbound TCP), `tests/nat-ip4-only.cfg`, `tests/connect.cfg`
and `tests/nstun-listen-lifecycle-authoritative.sh` behave exactly as on
master.
