### PR TITLE
contain: fail closed on incomplete file descriptor cleanup

### DIFF
--- a/contain.cc
+++ b/contain.cc
@@ -333,30 +333,16 @@ static bool containMakeFdsCOECloseRange(nsj_t* nsj) {
 	return true;
 }
 
-static bool containMakeFdsCOENaive(nsj_t* nsj) {
-	/*
-	 * Don't use getrlimit(RLIMIT_NOFILE) here, as it can return an artifically small value
-	 * (e.g. 32), which could be smaller than a maximum assigned number to file-descriptors
-	 * in this process. Just use some reasonably sane value (e.g. 1024)
-	 */
-	for (unsigned fd = 0; fd < 1024; fd++) {
-		RETURN_ON_FAILURE(containMakeFdCOE(fd, containPassFd(nsj, fd)));
-	}
-	return true;
-}
-
-static bool containMakeFdsCOEProc(nsj_t* nsj) {
-	int dirfd = open("/proc/self/fd", O_DIRECTORY | O_RDONLY | O_CLOEXEC);
-	if (dirfd == -1) {
-		PLOG_D("open('/proc/self/fd', O_DIRECTORY|O_RDONLY|O_CLOEXEC)");
+static bool containMakeFdsCOEProc(nsj_t* nsj, int* proc_fd) {
+	if (*proc_fd == -1) {
 		return false;
 	}
-	DIR* dir = fdopendir(dirfd);
+	DIR* dir = fdopendir(*proc_fd);
 	if (dir == nullptr) {
-		PLOG_W("fdopendir(fd=%d)", dirfd);
-		close(dirfd);
+		PLOG_W("fdopendir(fd=%d)", *proc_fd);
 		return false;
 	}
+	*proc_fd = -1; /* fdopendir() owns the descriptor now. */
 	/* Make all fds above stderr close-on-exec */
 	for (;;) {
 		errno = 0;
@@ -393,18 +379,15 @@ static bool containMakeFdsCOEProc(nsj_t* nsj) {
 	return true;
 }
 
-static bool containMakeFdsCOE(nsj_t* nsj) {
+static bool containMakeFdsCOE(nsj_t* nsj, int* proc_fd) {
 	RETURN_ON_FAILURE(containValidateDefaultStdioFds(nsj));
 	if (containMakeFdsCOECloseRange(nsj)) {
 		return true;
 	}
-	if (containMakeFdsCOEProc(nsj)) {
+	if (containMakeFdsCOEProc(nsj, proc_fd)) {
 		return true;
 	}
-	if (containMakeFdsCOENaive(nsj)) {
-		return true;
-	}
-	LOG_E("Couldn't mark relevant file-descriptors as close-on-exec with any known method");
+	LOG_E("Couldn't safely mark all file descriptors as close-on-exec");
 	return false;
 }
 
@@ -440,6 +423,16 @@ bool setupFD(nsj_t* nsj, int fd_in, int fd_out, int fd_err) {
 }
 
 bool containProc(nsj_t* nsj, int parent_fd, pid_t expected_parent) {
+	/* Keep a view of all descriptors available after mount/chroot setup removes /proc. */
+	int proc_fd = open("/proc/self/fd", O_DIRECTORY | O_RDONLY | O_CLOEXEC);
+	if (proc_fd == -1) {
+		PLOG_D("open('/proc/self/fd', O_DIRECTORY|O_RDONLY|O_CLOEXEC)");
+	}
+	defer {
+		if (proc_fd != -1) {
+			close(proc_fd);
+		}
+	};
 	RETURN_ON_FAILURE(containUserNs(nsj));
 	RETURN_ON_FAILURE(containInitPidNs(nsj));
 	RETURN_ON_FAILURE(containInitMountNs(nsj));
@@ -455,7 +448,7 @@ bool containProc(nsj_t* nsj, int parent_fd, pid_t expected_parent) {
 	RETURN_ON_FAILURE(containTSC(nsj));
 	RETURN_ON_FAILURE(containSetLimits(nsj));
 	RETURN_ON_FAILURE(containPrepareEnv(nsj, parent_fd, expected_parent));
-	RETURN_ON_FAILURE(containMakeFdsCOE(nsj));
+	RETURN_ON_FAILURE(containMakeFdsCOE(nsj, &proc_fd));
 
 	return true;
 }


### PR DESCRIPTION
## Summary

Ensure that file descriptor cleanup cannot silently leave high-numbered inherited descriptors open across `execve()`.

The existing fallback in `containMakeFdsCOENaive()` only scans descriptors 0 through 1023. If `close_range(CLOSE_RANGE_CLOEXEC)` fails and `/proc/self/fd` is unavailable after mount/chroot setup, an inheritable descriptor numbered 1024 or higher can therefore survive into the jailed process.

This change:

* opens `/proc/self/fd` before mount/chroot setup changes the filesystem view;
* retains that directory descriptor until final FD cleanup;
* uses it to enumerate all open descriptors if `close_range()` fails;
* removes the bounded 0..1023 fallback; and
* fails closed if neither complete cleanup mechanism is available.

## Security impact

A high-numbered inherited host descriptor can expose resources that were not explicitly passed with `--pass_fd`, including files, sockets, pipes, or directory descriptors.

Lowering `RLIMIT_NOFILE` does not address this because descriptors opened before the limit is lowered remain valid.

## Reproduction

The issue was reproduced by:

1. opening a host-only file as FD 2048;
2. forcing `close_range()` to return `ENOSYS`;
3. using `--disable_proc` with a minimal chroot; and
4. executing a static program in the jail that reads FD 2048.

Before this change, the jailed program can read the host-only descriptor.

With this change, the same descriptor does not survive `execve()`.

## Relation to #297

This is separate from #297.

The issue here is not primarily support for older kernels. The current containment path already attempts fallback cleanup when `close_range()` fails. The problem is that the final fallback can report success while only checking descriptors below 1024.

`close_range()` can also be unavailable to the process because of an outer syscall policy or similar execution environment, even on a kernel that implements it.

## Validation

* reproduced against `f100fd917c6d3ed0fd15d868528b735cb5fb1a1a`;
* patched behavior verified with the same high-FD reproducer;
* `git apply --check` passed;
* `git diff --check` passed;
* clean Ubuntu 24.04 build with `make clean && make -j2` passed.
